### PR TITLE
feat: Add prescriptions and order-tracking APIs

### DIFF
--- a/admin/rest/src/settings/site.settings.ts
+++ b/admin/rest/src/settings/site.settings.ts
@@ -267,6 +267,26 @@ export const siteSettings = {
         ],
       },
 
+      medical: {
+        href: '',
+        label: 'Medical Management',
+        icon: 'FountainPenIcon',
+        childMenu: [
+          {
+            href: Routes.prescriptions.list,
+            label: 'Prescriptions',
+            icon: 'FountainPenIcon',
+            permission: adminOwnerAndStaffOnly,
+          },
+          {
+            href: Routes.orderTracking.list,
+            label: 'Order Tracking',
+            icon: 'OrderTrackingIcon',
+            permission: adminOwnerAndStaffOnly,
+          },
+        ],
+      },
+
       order: {
         href: Routes.order.list,
         label: 'text-order-management',

--- a/api/rest/src/app.module.ts
+++ b/api/rest/src/app.module.ts
@@ -48,6 +48,8 @@ import { BecomeSellerModule } from './become-seller/become-seller.module';
 import { OwnershipTransferModule } from './ownership-transfer/ownership-transfer.module';
 import * as Joi from 'joi';
 import { StoreNoticesModule } from './store-notices/store-notices.module';
+import { PrescriptionsModule } from './prescriptions/prescriptions.module';
+import { OrderTrackingModule } from './order-tracking/order-tracking-module';
 
 @Module({
   imports: [
@@ -116,7 +118,9 @@ import { StoreNoticesModule } from './store-notices/store-notices.module';
     BecomeSellerModule,
     OwnershipTransferModule,
     TagsModule,
-    TaxesModule
+    TaxesModule,
+    PrescriptionsModule,
+    OrderTrackingModule,
   ],
   controllers: [],
   providers: [],

--- a/api/rest/src/order-tracking/dto/create-order-tracking.dto.ts
+++ b/api/rest/src/order-tracking/dto/create-order-tracking.dto.ts
@@ -1,0 +1,35 @@
+// order-tracking/dto/create-order-tracking.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsInt, IsString, IsOptional, IsDate } from 'class-validator';
+import { TrackingStatus } from '../entities/order-tracking.entity';
+
+export class CreateOrderTrackingDto {
+  @ApiProperty({ description: 'Order ID', example: 1 })
+  @IsNotEmpty()
+  @IsInt()
+  order_id: number;
+
+  @ApiProperty({ description: 'Tracking number', example: 'TRK123456789', required: false })
+  @IsOptional()
+  @IsString()
+  tracking_number?: string;
+
+  @ApiProperty({ description: 'Carrier/Courier name', example: 'FedEx', required: false })
+  @IsOptional()
+  @IsString()
+  carrier?: string;
+
+  @ApiProperty({ description: 'Current location', example: 'New York, NY', required: false })
+  @IsOptional()
+  @IsString()
+  current_location?: string;
+
+  @ApiProperty({ description: 'Estimated delivery date', example: '2024-02-15', required: false })
+  @IsOptional()
+  estimated_delivery_date?: Date;
+
+  @ApiProperty({ description: 'Initial notes', example: 'Order confirmed and ready to ship', required: false })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/api/rest/src/order-tracking/dto/get-order-tracking.dto.ts
+++ b/api/rest/src/order-tracking/dto/get-order-tracking.dto.ts
@@ -1,0 +1,44 @@
+// order-tracking/dto/get-order-tracking.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsInt, IsString, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
+import { TrackingStatus } from '../entities/order-tracking.entity';
+import { OrderTracking } from '../entities/order-tracking.entity';
+
+export class GetOrderTrackingDto extends PaginationArgs {
+  @ApiProperty({ description: 'Filter by order ID', example: 1, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  order_id?: number;
+
+  @ApiProperty({ description: 'Filter by tracking status', enum: TrackingStatus, required: false })
+  @IsOptional()
+  @IsEnum(TrackingStatus)
+  status?: TrackingStatus;
+
+  @ApiProperty({ description: 'Search by tracking number or carrier', example: 'TRK123', required: false })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiProperty({ description: 'Sort by field', example: 'created_at', required: false })
+  @IsOptional()
+  @IsString()
+  sortBy?: string;
+
+  @ApiProperty({ description: 'Sort order (asc or desc)', example: 'desc', required: false })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc';
+}
+
+export class OrderTrackingPaginator {
+  data: OrderTracking[];
+  paging: {
+    total: number;
+    limit: number;
+    page: number;
+  };
+}

--- a/api/rest/src/order-tracking/dto/update-order-tracking.dto.ts
+++ b/api/rest/src/order-tracking/dto/update-order-tracking.dto.ts
@@ -1,0 +1,30 @@
+// order-tracking/dto/update-order-tracking.dto.ts
+import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { CreateOrderTrackingDto } from './create-order-tracking.dto';
+import { IsOptional, IsEnum, IsString, IsInt } from 'class-validator';
+import { TrackingStatus } from '../entities/order-tracking.entity';
+
+export class UpdateOrderTrackingDto extends PartialType(CreateOrderTrackingDto) {
+  @ApiProperty({ description: 'Current tracking status', enum: TrackingStatus, required: false })
+  @IsOptional()
+  @IsEnum(TrackingStatus)
+  status?: TrackingStatus;
+
+  @ApiProperty({ description: 'Updated notes', example: 'Package in transit', required: false })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @ApiProperty({ description: 'Updated by (staff ID)', example: 1, required: false })
+  @IsOptional()
+  @IsInt()
+  updated_by?: number;
+
+  @ApiProperty({ description: 'Tracking details JSON', required: false })
+  @IsOptional()
+  tracking_details?: { steps?: string[]; updates?: any[] };
+
+  @ApiProperty({ description: 'Actual delivery date', example: '2024-02-14', required: false })
+  @IsOptional()
+  actual_delivery_date?: Date;
+}

--- a/api/rest/src/order-tracking/entities/order-tracking.entity.ts
+++ b/api/rest/src/order-tracking/entities/order-tracking.entity.ts
@@ -1,0 +1,67 @@
+// order-tracking/entities/order-tracking.entity.ts
+import { ApiProperty } from '@nestjs/swagger';
+import { CoreEntity } from 'src/common/entities/core.entity';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Order } from 'src/orders/entities/order.entity';
+
+export enum TrackingStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  PROCESSING = 'processing',
+  SHIPPED = 'shipped',
+  IN_TRANSIT = 'in-transit',
+  OUT_FOR_DELIVERY = 'out-for-delivery',
+  DELIVERED = 'delivered',
+  CANCELLED = 'cancelled',
+  RETURNED = 'returned',
+}
+
+@Entity('order_trackings')
+export class OrderTracking extends CoreEntity {
+  @ApiProperty({ description: 'Order ID', example: 1 })
+  @Column({ type: 'int', nullable: false })
+  order_id: number;
+
+  @ApiProperty({ description: 'Current tracking status', enum: TrackingStatus, default: TrackingStatus.PENDING })
+  @Column({ type: 'varchar', default: TrackingStatus.PENDING })
+  status: TrackingStatus;
+
+  @ApiProperty({ description: 'Tracking number', example: 'TRK123456789' })
+  @Column({ type: 'varchar', nullable: true })
+  tracking_number: string;
+
+  @ApiProperty({ description: 'Carrier/Courier name', example: 'FedEx' })
+  @Column({ type: 'varchar', nullable: true })
+  carrier: string;
+
+  @ApiProperty({ description: 'Current location', example: 'New York, NY' })
+  @Column({ type: 'varchar', nullable: true })
+  current_location: string;
+
+  @ApiProperty({ description: 'Estimated delivery date', example: '2024-02-15' })
+  @Column({ type: 'date', nullable: true })
+  estimated_delivery_date: Date;
+
+  @ApiProperty({ description: 'Actual delivery date', example: '2024-02-14' })
+  @Column({ type: 'date', nullable: true })
+  actual_delivery_date: Date;
+
+  @ApiProperty({ description: 'Tracking details in JSON', example: { steps: ['Order Confirmed', 'Processing'] } })
+  @Column({ type: 'simple-json', nullable: true })
+  tracking_details: { steps?: string[]; updates?: any[] };
+
+  @ApiProperty({ description: 'Notes from store owner/courier', example: 'Package left at door' })
+  @Column({ type: 'text', nullable: true })
+  notes: string;
+
+  @ApiProperty({ description: 'Last updated timestamp' })
+  @Column({ type: 'datetime', nullable: true })
+  last_updated: Date;
+
+  @ApiProperty({ description: 'Updated by (staff ID)', example: 1 })
+  @Column({ type: 'int', nullable: true })
+  updated_by: number;
+
+  @ApiProperty({ description: 'Order relation', type: () => Order })
+  order?: Order;
+}

--- a/api/rest/src/order-tracking/order-tracking-module.ts
+++ b/api/rest/src/order-tracking/order-tracking-module.ts
@@ -1,0 +1,13 @@
+// order-tracking/order-tracking.module.ts
+import { Module } from '@nestjs/common';
+import { AuthModule } from 'src/auth/auth.module';
+import { OrderTrackingController } from './order-tracking.controller';
+import { OrderTrackingService } from './order-tracking.service';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [OrderTrackingController],
+  providers: [OrderTrackingService],
+  exports: [OrderTrackingService],
+})
+export class OrderTrackingModule {}

--- a/api/rest/src/order-tracking/order-tracking.controller.ts
+++ b/api/rest/src/order-tracking/order-tracking.controller.ts
@@ -1,0 +1,239 @@
+// order-tracking/order-tracking.controller.ts
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiBody,
+  ApiParam,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { OrderTrackingService } from './order-tracking.service';
+import { CreateOrderTrackingDto } from './dto/create-order-tracking.dto';
+import { UpdateOrderTrackingDto } from './dto/update-order-tracking.dto';
+import { GetOrderTrackingDto, OrderTrackingPaginator } from './dto/get-order-tracking.dto';
+import { OrderTracking } from './entities/order-tracking.entity';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Permission } from 'src/common/enums/enums';
+
+@ApiTags('📦 Order Tracking')
+@Controller('order-tracking')
+export class OrderTrackingController {
+  constructor(private readonly orderTrackingService: OrderTrackingService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Create order tracking (Admin/Staff only)',
+    description: 'Create a new tracking record for an order',
+  })
+  @ApiCreatedResponse({
+    description: 'Order tracking created successfully',
+    type: OrderTracking,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid input data' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({ type: CreateOrderTrackingDto })
+  async create(@Body() createOrderTrackingDto: CreateOrderTrackingDto): Promise<OrderTracking> {
+    return this.orderTrackingService.create(createOrderTrackingDto);
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get all order trackings (Admin/Staff only)',
+    description: 'Retrieve paginated list of order trackings',
+  })
+  @ApiOkResponse({
+    description: 'Order trackings retrieved successfully',
+    type: OrderTrackingPaginator,
+  })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiQuery({ name: 'page', description: 'Page number', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', description: 'Items per page', required: false, example: 15 })
+  @ApiQuery({ name: 'order_id', description: 'Filter by order ID', required: false })
+  @ApiQuery({ name: 'status', description: 'Filter by status', required: false })
+  @ApiQuery({ name: 'search', description: 'Search query', required: false })
+  async findAll(@Query() query: GetOrderTrackingDto): Promise<OrderTrackingPaginator> {
+    return this.orderTrackingService.findAll(query);
+  }
+
+  @Get('order/:orderId')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF, Permission.CUSTOMER)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get tracking by order ID',
+    description: 'Retrieve tracking information for a specific order',
+  })
+  @ApiParam({
+    name: 'orderId',
+    description: 'Order ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Order tracking retrieved successfully',
+    type: OrderTracking,
+  })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  async findByOrderId(
+    @Param('orderId', ParseIntPipe) orderId: number,
+  ): Promise<OrderTracking> {
+    return this.orderTrackingService.findByOrderId(orderId);
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF, Permission.CUSTOMER)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get order tracking by ID',
+    description: 'Retrieve tracking details by ID',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Tracking ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Order tracking retrieved successfully',
+    type: OrderTracking,
+  })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  async findOne(@Param('id', ParseIntPipe) id: number): Promise<OrderTracking> {
+    return this.orderTrackingService.findOne(id);
+  }
+
+  @Put(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Update order tracking (Admin/Staff only)',
+    description: 'Update tracking status and details',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Tracking ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Order tracking updated successfully',
+    type: OrderTracking,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid input data' })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({ type: UpdateOrderTrackingDto })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateOrderTrackingDto: UpdateOrderTrackingDto,
+  ): Promise<OrderTracking> {
+    return this.orderTrackingService.update(id, updateOrderTrackingDto);
+  }
+
+  @Post(':id/update-status')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Update tracking status (Admin/Staff only)',
+    description: 'Update the current status of order tracking',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Tracking ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Tracking status updated successfully',
+    type: OrderTracking,
+  })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', example: 'in-transit' },
+        staffId: { type: 'number', example: 1 },
+        notes: { type: 'string', example: 'Package in transit' },
+      },
+    },
+  })
+  async updateStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body('status') status: string,
+    @Body('staffId', ParseIntPipe) staffId: number,
+    @Body('notes') notes?: string,
+  ): Promise<OrderTracking> {
+    return this.orderTrackingService.updateStatus(id, status as any, staffId, notes);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Delete order tracking (Admin/Staff only)',
+    description: 'Delete an order tracking record',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Tracking ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Order tracking deleted successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean' },
+        message: { type: 'string' },
+      },
+    },
+  })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<{ success: boolean; message: string }> {
+    return this.orderTrackingService.remove(id);
+  }
+}

--- a/api/rest/src/order-tracking/order-tracking.module.ts
+++ b/api/rest/src/order-tracking/order-tracking.module.ts
@@ -1,0 +1,239 @@
+// order-tracking/order-tracking.controller.ts
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiBody,
+  ApiParam,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { OrderTrackingService } from './order-tracking.service';
+import { CreateOrderTrackingDto } from './dto/create-order-tracking.dto';
+import { UpdateOrderTrackingDto } from './dto/update-order-tracking.dto';
+import { GetOrderTrackingDto, OrderTrackingPaginator } from './dto/get-order-tracking.dto';
+import { OrderTracking } from './entities/order-tracking.entity';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Permission } from 'src/common/enums/enums';
+
+@ApiTags('📦 Order Tracking')
+@Controller('order-tracking')
+export class OrderTrackingController {
+  constructor(private readonly orderTrackingService: OrderTrackingService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Create order tracking (Admin/Staff only)',
+    description: 'Create a new tracking record for an order',
+  })
+  @ApiCreatedResponse({
+    description: 'Order tracking created successfully',
+    type: OrderTracking,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid input data' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({ type: CreateOrderTrackingDto })
+  async create(@Body() createOrderTrackingDto: CreateOrderTrackingDto): Promise<OrderTracking> {
+    return this.orderTrackingService.create(createOrderTrackingDto);
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get all order trackings (Admin/Staff only)',
+    description: 'Retrieve paginated list of order trackings',
+  })
+  @ApiOkResponse({
+    description: 'Order trackings retrieved successfully',
+    type: OrderTrackingPaginator,
+  })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiQuery({ name: 'page', description: 'Page number', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', description: 'Items per page', required: false, example: 15 })
+  @ApiQuery({ name: 'order_id', description: 'Filter by order ID', required: false })
+  @ApiQuery({ name: 'status', description: 'Filter by status', required: false })
+  @ApiQuery({ name: 'search', description: 'Search query', required: false })
+  async findAll(@Query() query: GetOrderTrackingDto): Promise<OrderTrackingPaginator> {
+    return this.orderTrackingService.findAll(query);
+  }
+
+  @Get('order/:orderId')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF, Permission.CUSTOMER)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get tracking by order ID',
+    description: 'Retrieve tracking information for a specific order',
+  })
+  @ApiParam({
+    name: 'orderId',
+    description: 'Order ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Order tracking retrieved successfully',
+    type: OrderTracking,
+  })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  async findByOrderId(
+    @Param('orderId', ParseIntPipe) orderId: number,
+  ): Promise<OrderTracking> {
+    return this.orderTrackingService.findByOrderId(orderId);
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF, Permission.CUSTOMER)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get order tracking by ID',
+    description: 'Retrieve tracking details by ID',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Tracking ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Order tracking retrieved successfully',
+    type: OrderTracking,
+  })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  async findOne(@Param('id', ParseIntPipe) id: number): Promise<OrderTracking> {
+    return this.orderTrackingService.findOne(id);
+  }
+
+  @Put(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Update order tracking (Admin/Staff only)',
+    description: 'Update tracking status and details',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Tracking ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Order tracking updated successfully',
+    type: OrderTracking,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid input data' })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({ type: UpdateOrderTrackingDto })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateOrderTrackingDto: UpdateOrderTrackingDto,
+  ): Promise<OrderTracking> {
+    return this.orderTrackingService.update(id, updateOrderTrackingDto);
+  }
+
+  @Post(':id/update-status')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Update tracking status (Admin/Staff only)',
+    description: 'Update the current status of order tracking',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Tracking ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Tracking status updated successfully',
+    type: OrderTracking,
+  })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', example: 'in-transit' },
+        staffId: { type: 'number', example: 1 },
+        notes: { type: 'string', example: 'Package in transit' },
+      },
+    },
+  })
+  async updateStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body('status') status: string,
+    @Body('staffId', ParseIntPipe) staffId: number,
+    @Body('notes') notes?: string,
+  ): Promise<OrderTracking> {
+    return this.orderTrackingService.updateStatus(id, status as any, staffId, notes);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Delete order tracking (Admin/Staff only)',
+    description: 'Delete an order tracking record',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Tracking ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Order tracking deleted successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean' },
+        message: { type: 'string' },
+      },
+    },
+  })
+  @ApiNotFoundResponse({ description: 'Tracking not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<{ success: boolean; message: string }> {
+    return this.orderTrackingService.remove(id);
+  }
+}

--- a/api/rest/src/order-tracking/order-tracking.service.ts
+++ b/api/rest/src/order-tracking/order-tracking.service.ts
@@ -1,0 +1,155 @@
+// order-tracking/order-tracking.service.ts
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { CreateOrderTrackingDto } from './dto/create-order-tracking.dto';
+import { UpdateOrderTrackingDto } from './dto/update-order-tracking.dto';
+import { GetOrderTrackingDto, OrderTrackingPaginator } from './dto/get-order-tracking.dto';
+import { OrderTracking, TrackingStatus } from './entities/order-tracking.entity';
+
+@Injectable()
+export class OrderTrackingService {
+  // Mock data - replace with actual database calls using TypeOrmModule in real implementation
+  private trackings: OrderTracking[] = [];
+  private idCounter = 1;
+
+  async create(createOrderTrackingDto: CreateOrderTrackingDto): Promise<OrderTracking> {
+    const tracking = new OrderTracking();
+    tracking.id = this.idCounter++;
+    tracking.order_id = createOrderTrackingDto.order_id;
+    tracking.tracking_number = createOrderTrackingDto.tracking_number;
+    tracking.carrier = createOrderTrackingDto.carrier;
+    tracking.current_location = createOrderTrackingDto.current_location;
+    tracking.estimated_delivery_date = createOrderTrackingDto.estimated_delivery_date;
+    tracking.notes = createOrderTrackingDto.notes;
+    tracking.status = TrackingStatus.PENDING;
+    tracking.last_updated = new Date();
+    tracking.created_at = new Date();
+    tracking.updated_at = new Date();
+
+    this.trackings.push(tracking);
+    return tracking;
+  }
+
+  async findAll(query: GetOrderTrackingDto): Promise<OrderTrackingPaginator> {
+    let filtered = [...this.trackings];
+
+    // Apply filters
+    if (query.order_id) {
+      filtered = filtered.filter(t => t.order_id === query.order_id);
+    }
+
+    if (query.status) {
+      filtered = filtered.filter(t => t.status === query.status);
+    }
+
+    if (query.search) {
+      const search = query.search.toLowerCase();
+      filtered = filtered.filter(t =>
+        t.tracking_number?.toLowerCase().includes(search) ||
+        t.carrier?.toLowerCase().includes(search) ||
+        t.current_location?.toLowerCase().includes(search)
+      );
+    }
+
+    // Apply sorting
+    const sortBy = query.sortBy || 'created_at';
+    const sortOrder = query.sortOrder || 'desc';
+    filtered.sort((a, b) => {
+      const aVal = a[sortBy] || 0;
+      const bVal = b[sortBy] || 0;
+      if (aVal < bVal) return sortOrder === 'asc' ? -1 : 1;
+      if (aVal > bVal) return sortOrder === 'asc' ? 1 : -1;
+      return 0;
+    });
+
+    // Apply pagination
+    const limit = query.limit || 15;
+    const page = query.page || 1;
+    const skip = (page - 1) * limit;
+    const data = filtered.slice(skip, skip + limit);
+
+    return {
+      data,
+      paging: {
+        total: filtered.length,
+        limit,
+        page,
+      },
+    };
+  }
+
+  async findOne(id: number): Promise<OrderTracking> {
+    const tracking = this.trackings.find(t => t.id === id);
+    if (!tracking) {
+      throw new NotFoundException(`Order tracking with ID ${id} not found`);
+    }
+    return tracking;
+  }
+
+  async findByOrderId(orderId: number): Promise<OrderTracking> {
+    const tracking = this.trackings.find(t => t.order_id === orderId);
+    if (!tracking) {
+      throw new NotFoundException(`Tracking for order ID ${orderId} not found`);
+    }
+    return tracking;
+  }
+
+  async update(id: number, updateOrderTrackingDto: UpdateOrderTrackingDto): Promise<OrderTracking> {
+    const tracking = await this.findOne(id);
+
+    if (updateOrderTrackingDto.status !== undefined) {
+      tracking.status = updateOrderTrackingDto.status;
+    }
+
+    if (updateOrderTrackingDto.current_location) {
+      tracking.current_location = updateOrderTrackingDto.current_location;
+    }
+
+    if (updateOrderTrackingDto.notes) {
+      tracking.notes = updateOrderTrackingDto.notes;
+    }
+
+    if (updateOrderTrackingDto.updated_by) {
+      tracking.updated_by = updateOrderTrackingDto.updated_by;
+    }
+
+    if (updateOrderTrackingDto.tracking_details) {
+      tracking.tracking_details = updateOrderTrackingDto.tracking_details;
+    }
+
+    if (updateOrderTrackingDto.actual_delivery_date) {
+      tracking.actual_delivery_date = updateOrderTrackingDto.actual_delivery_date;
+    }
+
+    tracking.last_updated = new Date();
+    tracking.updated_at = new Date();
+    return tracking;
+  }
+
+  async remove(id: number): Promise<{ success: boolean; message: string }> {
+    const index = this.trackings.findIndex(t => t.id === id);
+    if (index === -1) {
+      throw new NotFoundException(`Order tracking with ID ${id} not found`);
+    }
+    this.trackings.splice(index, 1);
+    return { success: true, message: 'Order tracking deleted successfully' };
+  }
+
+  async updateStatus(id: number, status: TrackingStatus, staffId: number, notes?: string): Promise<OrderTracking> {
+    const tracking = await this.findOne(id);
+    tracking.status = status;
+    tracking.updated_by = staffId;
+    tracking.last_updated = new Date();
+    tracking.updated_at = new Date();
+
+    if (notes) {
+      tracking.notes = notes;
+    }
+
+    // Auto-set delivery date if delivered
+    if (status === TrackingStatus.DELIVERED) {
+      tracking.actual_delivery_date = new Date();
+    }
+
+    return tracking;
+  }
+}

--- a/api/rest/src/prescriptions/dto/create-prescription.dto.ts
+++ b/api/rest/src/prescriptions/dto/create-prescription.dto.ts
@@ -1,0 +1,44 @@
+// prescriptions/dto/create-prescription.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsInt, IsOptional, IsDate } from 'class-validator';
+import { PrescriptionStatus } from '../entities/prescription.entity';
+
+export class CreatePrescriptionDto {
+  @ApiProperty({ description: 'Customer ID', example: 1 })
+  @IsNotEmpty()
+  @IsInt()
+  customer_id: number;
+
+  @ApiProperty({ description: 'Shop ID', example: 1 })
+  @IsNotEmpty()
+  @IsInt()
+  shop_id: number;
+
+  @ApiProperty({ description: 'Prescription file URL', example: 'https://example.com/prescription.pdf' })
+  @IsNotEmpty()
+  @IsString()
+  prescription_file: string;
+
+  @ApiProperty({ description: 'Doctor name', example: 'Dr. John Doe', required: false })
+  @IsOptional()
+  @IsString()
+  doctor_name?: string;
+
+  @ApiProperty({ description: 'Hospital name', example: 'City Hospital', required: false })
+  @IsOptional()
+  @IsString()
+  hospital_name?: string;
+
+  @ApiProperty({ description: 'Prescription date', example: '2024-01-15', required: false })
+  @IsOptional()
+  prescription_date?: Date;
+
+  @ApiProperty({ description: 'Expiry date', example: '2024-03-15', required: false })
+  @IsOptional()
+  expiry_date?: Date;
+
+  @ApiProperty({ description: 'Customer notes', example: 'Urgent prescription', required: false })
+  @IsOptional()
+  @IsString()
+  customer_notes?: string;
+}

--- a/api/rest/src/prescriptions/dto/get-prescriptions.dto.ts
+++ b/api/rest/src/prescriptions/dto/get-prescriptions.dto.ts
@@ -1,0 +1,50 @@
+// prescriptions/dto/get-prescriptions.dto.ts
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsInt, IsString, IsEnum, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
+import { PrescriptionStatus } from '../entities/prescription.entity';
+import { Prescription } from '../entities/prescription.entity';
+
+export class GetPrescriptionsDto extends PaginationArgs {
+  @ApiProperty({ description: 'Search by customer name or ID', example: 'John', required: false })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiProperty({ description: 'Filter by shop ID', example: 1, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  shop_id?: number;
+
+  @ApiProperty({ description: 'Filter by status', enum: PrescriptionStatus, required: false })
+  @IsOptional()
+  @IsEnum(PrescriptionStatus)
+  status?: PrescriptionStatus;
+
+  @ApiProperty({ description: 'Filter by customer ID', example: 1, required: false })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  customer_id?: number;
+
+  @ApiProperty({ description: 'Sort by field', example: 'created_at', required: false })
+  @IsOptional()
+  @IsString()
+  sortBy?: string;
+
+  @ApiProperty({ description: 'Sort order (asc or desc)', example: 'desc', required: false })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'asc' | 'desc';
+}
+
+export class PrescriptionPaginator {
+  data: Prescription[];
+  paging: {
+    total: number;
+    limit: number;
+    page: number;
+  };
+}

--- a/api/rest/src/prescriptions/dto/update-prescription.dto.ts
+++ b/api/rest/src/prescriptions/dto/update-prescription.dto.ts
@@ -1,0 +1,22 @@
+// prescriptions/dto/update-prescription.dto.ts
+import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { CreatePrescriptionDto } from './create-prescription.dto';
+import { IsOptional, IsEnum, IsString, IsInt } from 'class-validator';
+import { PrescriptionStatus } from '../entities/prescription.entity';
+
+export class UpdatePrescriptionDto extends PartialType(CreatePrescriptionDto) {
+  @ApiProperty({ description: 'Prescription status', enum: PrescriptionStatus, required: false })
+  @IsOptional()
+  @IsEnum(PrescriptionStatus)
+  status?: PrescriptionStatus;
+
+  @ApiProperty({ description: 'Admin notes', example: 'Prescription verified', required: false })
+  @IsOptional()
+  @IsString()
+  admin_notes?: string;
+
+  @ApiProperty({ description: 'Approved by (staff ID)', example: 1, required: false })
+  @IsOptional()
+  @IsInt()
+  approved_by?: number;
+}

--- a/api/rest/src/prescriptions/entities/prescription.entity.ts
+++ b/api/rest/src/prescriptions/entities/prescription.entity.ts
@@ -1,0 +1,73 @@
+// prescriptions/entities/prescription.entity.ts
+import { ApiProperty } from '@nestjs/swagger';
+import { CoreEntity } from 'src/common/entities/core.entity';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { User } from 'src/users/entities/user.entity';
+import { Shop } from 'src/shops/entities/shop.entity';
+
+export enum PrescriptionStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  EXPIRED = 'expired',
+}
+
+@Entity('prescriptions')
+export class Prescription extends CoreEntity {
+  @ApiProperty({ description: 'Customer ID', example: 1 })
+  @Column({ type: 'int', nullable: false })
+  customer_id: number;
+
+  @ApiProperty({ description: 'Shop ID', example: 1 })
+  @Column({ type: 'int', nullable: false })
+  shop_id: number;
+
+  @ApiProperty({ description: 'Prescription file URL', example: 'https://example.com/prescription.pdf' })
+  @Column({ type: 'varchar', nullable: false })
+  prescription_file: string;
+
+  @ApiProperty({ description: 'Prescription status', enum: PrescriptionStatus, default: PrescriptionStatus.PENDING })
+  @Column({ type: 'varchar', default: PrescriptionStatus.PENDING })
+  status: PrescriptionStatus;
+
+  @ApiProperty({ description: 'Doctor name', example: 'Dr. John Doe' })
+  @Column({ type: 'varchar', nullable: true })
+  doctor_name: string;
+
+  @ApiProperty({ description: 'Hospital name', example: 'City Hospital' })
+  @Column({ type: 'varchar', nullable: true })
+  hospital_name: string;
+
+  @ApiProperty({ description: 'Prescription date', example: '2024-01-15' })
+  @Column({ type: 'date', nullable: true })
+  prescription_date: Date;
+
+  @ApiProperty({ description: 'Expiry date', example: '2024-03-15' })
+  @Column({ type: 'date', nullable: true })
+  expiry_date: Date;
+
+  @ApiProperty({ description: 'Admin notes', example: 'Prescription verified' })
+  @Column({ type: 'text', nullable: true })
+  admin_notes: string;
+
+  @ApiProperty({ description: 'Customer notes', example: 'Urgent prescription' })
+  @Column({ type: 'text', nullable: true })
+  customer_notes: string;
+
+  @ApiProperty({ description: 'Approved/Rejected by (staff ID)', example: 1 })
+  @Column({ type: 'int', nullable: true })
+  approved_by: number;
+
+  @ApiProperty({ description: 'Approval timestamp' })
+  @Column({ type: 'datetime', nullable: true })
+  approved_at: Date;
+
+  @ApiProperty({ description: 'Customer relation', type: () => User })
+  customer?: User;
+
+  @ApiProperty({ description: 'Shop relation', type: () => Shop })
+  shop?: Shop;
+
+  @ApiProperty({ description: 'Approved by user relation', type: () => User })
+  approved_by_user?: User;
+}

--- a/api/rest/src/prescriptions/prescriptions.controller.ts
+++ b/api/rest/src/prescriptions/prescriptions.controller.ts
@@ -1,0 +1,276 @@
+// prescriptions/prescriptions.controller.ts
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiBody,
+  ApiParam,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { PrescriptionsService } from './prescriptions.service';
+import { CreatePrescriptionDto } from './dto/create-prescription.dto';
+import { UpdatePrescriptionDto } from './dto/update-prescription.dto';
+import { GetPrescriptionsDto, PrescriptionPaginator } from './dto/get-prescriptions.dto';
+import { Prescription } from './entities/prescription.entity';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Permission } from 'src/common/enums/enums';
+import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
+
+@ApiTags('💊 Prescriptions')
+@Controller('prescriptions')
+export class PrescriptionsController {
+  constructor(private readonly prescriptionsService: PrescriptionsService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.CUSTOMER)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Upload prescription',
+    description: 'Customer can upload their prescription for approval',
+  })
+  @ApiCreatedResponse({
+    description: 'Prescription uploaded successfully',
+    type: Prescription,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid input data' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Only customers can upload prescriptions' })
+  @ApiBody({ type: CreatePrescriptionDto })
+  async create(@Body() createPrescriptionDto: CreatePrescriptionDto): Promise<Prescription> {
+    return this.prescriptionsService.create(createPrescriptionDto);
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get all prescriptions (Admin/Staff only)',
+    description: 'Retrieve paginated list of prescriptions - only accessible to store owner, admin, and staff',
+  })
+  @ApiOkResponse({
+    description: 'Prescriptions retrieved successfully',
+    type: PrescriptionPaginator,
+  })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiQuery({ name: 'page', description: 'Page number', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', description: 'Items per page', required: false, example: 15 })
+  @ApiQuery({ name: 'search', description: 'Search query', required: false })
+  @ApiQuery({ name: 'status', description: 'Filter by status', required: false })
+  @ApiQuery({ name: 'shop_id', description: 'Filter by shop ID', required: false })
+  async findAll(@Query() query: GetPrescriptionsDto): Promise<PrescriptionPaginator> {
+    return this.prescriptionsService.findAll(query);
+  }
+
+  @Get('customer/:customerId')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF, Permission.CUSTOMER)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get prescriptions by customer ID',
+    description: 'Get all prescriptions for a specific customer',
+  })
+  @ApiParam({
+    name: 'customerId',
+    description: 'Customer ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Prescriptions retrieved successfully',
+    type: [Prescription],
+  })
+  @ApiNotFoundResponse({ description: 'No prescriptions found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  async getCustomerPrescriptions(
+    @Param('customerId', ParseIntPipe) customerId: number,
+  ): Promise<Prescription[]> {
+    return this.prescriptionsService.findByCustomerId(customerId);
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF, Permission.CUSTOMER)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get prescription by ID',
+    description: 'Retrieve prescription details by ID',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Prescription ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Prescription retrieved successfully',
+    type: Prescription,
+  })
+  @ApiNotFoundResponse({ description: 'Prescription not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  async findOne(@Param('id', ParseIntPipe) id: number): Promise<Prescription> {
+    return this.prescriptionsService.findOne(id);
+  }
+
+  @Put(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Update prescription (Admin/Staff only)',
+    description: 'Update prescription status and notes',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Prescription ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Prescription updated successfully',
+    type: Prescription,
+  })
+  @ApiBadRequestResponse({ description: 'Invalid input data' })
+  @ApiNotFoundResponse({ description: 'Prescription not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({ type: UpdatePrescriptionDto })
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updatePrescriptionDto: UpdatePrescriptionDto,
+  ): Promise<Prescription> {
+    return this.prescriptionsService.update(id, updatePrescriptionDto);
+  }
+
+  @Post(':id/approve')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Approve prescription (Admin/Staff only)',
+    description: 'Approve a prescription for use',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Prescription ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Prescription approved successfully',
+    type: Prescription,
+  })
+  @ApiNotFoundResponse({ description: 'Prescription not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        staffId: { type: 'number', example: 1 },
+        notes: { type: 'string', example: 'Prescription verified' },
+      },
+    },
+  })
+  async approvePrescription(
+    @Param('id', ParseIntPipe) id: number,
+    @Body('staffId', ParseIntPipe) staffId: number,
+    @Body('notes') notes: string,
+  ): Promise<Prescription> {
+    return this.prescriptionsService.approvePrescription(id, staffId, notes);
+  }
+
+  @Post(':id/reject')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Reject prescription (Admin/Staff only)',
+    description: 'Reject a prescription with reason',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Prescription ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Prescription rejected successfully',
+    type: Prescription,
+  })
+  @ApiNotFoundResponse({ description: 'Prescription not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        staffId: { type: 'number', example: 1 },
+        notes: { type: 'string', example: 'Invalid prescription format' },
+      },
+    },
+  })
+  async rejectPrescription(
+    @Param('id', ParseIntPipe) id: number,
+    @Body('staffId', ParseIntPipe) staffId: number,
+    @Body('notes') notes: string,
+  ): Promise<Prescription> {
+    return this.prescriptionsService.rejectPrescription(id, staffId, notes);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.STAFF)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Delete prescription (Admin/Staff only)',
+    description: 'Delete a prescription',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Prescription ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Prescription deleted successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean' },
+        message: { type: 'string' },
+      },
+    },
+  })
+  @ApiNotFoundResponse({ description: 'Prescription not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<{ success: boolean; message: string }> {
+    return this.prescriptionsService.remove(id);
+  }
+}

--- a/api/rest/src/prescriptions/prescriptions.module.ts
+++ b/api/rest/src/prescriptions/prescriptions.module.ts
@@ -1,0 +1,15 @@
+// prescriptions/prescriptions.module.ts
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
+import { PrescriptionsController } from './prescriptions.controller';
+import { PrescriptionsService } from './prescriptions.service';
+import { Prescription } from './entities/prescription.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Prescription]), AuthModule],
+  controllers: [PrescriptionsController],
+  providers: [PrescriptionsService],
+  exports: [PrescriptionsService],
+})
+export class PrescriptionsModule {}

--- a/api/rest/src/prescriptions/prescriptions.service.ts
+++ b/api/rest/src/prescriptions/prescriptions.service.ts
@@ -1,0 +1,116 @@
+// prescriptions/prescriptions.service.ts
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreatePrescriptionDto } from './dto/create-prescription.dto';
+import { UpdatePrescriptionDto } from './dto/update-prescription.dto';
+import { GetPrescriptionsDto, PrescriptionPaginator } from './dto/get-prescriptions.dto';
+import { Prescription, PrescriptionStatus } from './entities/prescription.entity';
+import { paginate } from 'src/common/pagination/paginate';
+
+@Injectable()
+export class PrescriptionsService {
+  constructor(
+    @InjectRepository(Prescription)
+    private prescriptionsRepository: Repository<Prescription>,
+  ) {}
+
+  async create(createPrescriptionDto: CreatePrescriptionDto): Promise<Prescription> {
+    const prescription = this.prescriptionsRepository.create({
+      ...createPrescriptionDto,
+      status: PrescriptionStatus.PENDING,
+    });
+
+    const saved = await this.prescriptionsRepository.save(prescription);
+    return this.findOne(saved.id);
+  }
+
+  async findAll(query: GetPrescriptionsDto): Promise<PrescriptionPaginator> {
+    const qb = this.prescriptionsRepository.createQueryBuilder('prescription')
+      .leftJoinAndSelect('prescription.customer', 'customer')
+      .leftJoinAndSelect('prescription.shop', 'shop');
+
+    if (query.search) {
+      const search = `%${query.search}%`;
+      qb.andWhere(
+        '(prescription.doctor_name LIKE :search OR prescription.hospital_name LIKE :search OR prescription.customer_notes LIKE :search)',
+        { search },
+      );
+    }
+
+    if (query.shop_id) qb.andWhere('prescription.shop_id = :shop_id', { shop_id: query.shop_id });
+    if (query.status) qb.andWhere('prescription.status = :status', { status: query.status });
+    if (query.customer_id) qb.andWhere('prescription.customer_id = :customer_id', { customer_id: query.customer_id });
+
+    const sortBy = query.sortBy || 'prescription.created_at';
+    const sortOrder = (query.sortOrder || 'DESC').toUpperCase();
+    qb.orderBy(sortBy, sortOrder as 'ASC' | 'DESC');
+
+    const limit = query.limit || 15;
+    const page = query.page || 1;
+    qb.skip((page - 1) * limit).take(limit);
+
+    const [data, total] = await qb.getManyAndCount();
+
+    return {
+      data,
+      paging: {
+        total,
+        limit,
+        page,
+      },
+    };
+  }
+
+  async findOne(id: number): Promise<Prescription> {
+    const prescription = await this.prescriptionsRepository.findOne({
+      where: { id },
+      relations: ['customer', 'shop'],
+    });
+
+    if (!prescription) throw new NotFoundException(`Prescription with ID ${id} not found`);
+    return prescription;
+  }
+
+  async findByCustomerId(customerId: number): Promise<Prescription[]> {
+    return this.prescriptionsRepository.find({ where: { customer_id: customerId } });
+  }
+
+  async update(id: number, updatePrescriptionDto: UpdatePrescriptionDto): Promise<Prescription> {
+    const prescription = await this.findOne(id);
+
+    Object.assign(prescription, updatePrescriptionDto);
+    if (updatePrescriptionDto.approved_by) prescription.approved_at = new Date();
+
+    await this.prescriptionsRepository.save(prescription);
+    return this.findOne(id);
+  }
+
+  async remove(id: number): Promise<{ success: boolean; message: string }> {
+    const prescription = await this.findOne(id);
+    await this.prescriptionsRepository.delete(prescription.id);
+    return { success: true, message: 'Prescription deleted successfully' };
+  }
+
+  async approvePrescription(id: number, staffId: number, notes: string): Promise<Prescription> {
+    const prescription = await this.findOne(id);
+    prescription.status = PrescriptionStatus.APPROVED;
+    prescription.approved_by = staffId;
+    prescription.approved_at = new Date();
+    prescription.admin_notes = notes;
+
+    await this.prescriptionsRepository.save(prescription);
+    return this.findOne(id);
+  }
+
+  async rejectPrescription(id: number, staffId: number, notes: string): Promise<Prescription> {
+    const prescription = await this.findOne(id);
+    prescription.status = PrescriptionStatus.REJECTED;
+    prescription.approved_by = staffId;
+    prescription.approved_at = new Date();
+    prescription.admin_notes = notes;
+
+    await this.prescriptionsRepository.save(prescription);
+    return this.findOne(id);
+  }
+}


### PR DESCRIPTION
Introduce Medical Management features: add admin menu entries and implement new prescriptions and order-tracking modules. Files added include DTOs, entities, controllers, services and Nest modules for prescriptions and order-tracking, plus registration of both modules in app.module.ts. Prescriptions service is TypeORM-backed with pagination and endpoints for create/list/get/update/approve/reject/delete; order-tracking adds CRUD endpoints and status updates (service currently uses an in-memory mock implementation). Also add paging/sorting DTOs and OpenAPI decorators and enforce role/guard checks on endpoints.