### PR TITLE
feat: Improve conversations API: filtering, perms, soft delete

### DIFF
--- a/api/rest/src/common/enums/conversation-order-by.enum.ts
+++ b/api/rest/src/common/enums/conversation-order-by.enum.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum ConversationOrderByColumn {
+  CREATED_AT = 'created_at',
+  UPDATED_AT = 'updated_at',
+  USER_ID = 'user_id',
+  SHOP_ID = 'shop_id',
+  UNSEEN = 'unseen',
+}

--- a/api/rest/src/conversations/conversations.controller.ts
+++ b/api/rest/src/conversations/conversations.controller.ts
@@ -1,4 +1,3 @@
-// conversations/conversations.controller.ts
 import {
   Body,
   Controller,
@@ -14,7 +13,6 @@ import {
 import {
   ApiTags,
   ApiOperation,
-  ApiResponse,
   ApiBearerAuth,
   ApiBody,
   ApiParam,
@@ -39,7 +37,9 @@ import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { Permission } from '../common/enums/enums';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
-import {Roles} from "../common/decorators/roles.decorator";
+import { Roles } from "../common/decorators/roles.decorator";
+
+import { SortOrder } from '../common/enums/enums';
 
 @ApiTags('💬 Conversations')
 @Controller('conversations')
@@ -56,16 +56,16 @@ export class ConversationsController {
   })
   @ApiCreatedResponse({
     description: 'Conversation created successfully',
-    type: Conversation,
+    type: () => Conversation,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @ApiBody({ type: CreateConversationDto })
-  createConversation(
+  create(
     @Body() createConversationDto: CreateConversationDto,
     @CurrentUser() user: any,
   ): Promise<Conversation> {
-    // If user is not admin, use their own ID
     if (!user?.permissions?.includes(Permission.SUPER_ADMIN)) {
       createConversationDto.user_id = user.id;
     }
@@ -73,7 +73,7 @@ export class ConversationsController {
   }
 
   @Get()
-  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER)
+  @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.CUSTOMER)
   @ApiOperation({
     summary: 'Get all conversations',
     description: 'Retrieve paginated list of all conversations',
@@ -84,11 +84,10 @@ export class ConversationsController {
   })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
-  async getConversations(
+  findAll(
     @Query() query: GetConversationsDto,
     @CurrentUser() user: any,
   ): Promise<ConversationPaginator> {
-    // Filter by user if not admin
     if (!user?.permissions?.includes(Permission.SUPER_ADMIN)) {
       if (user?.permissions?.includes(Permission.STORE_OWNER)) {
         query.shop_id = user.shop_id;
@@ -96,26 +95,27 @@ export class ConversationsController {
         query.user_id = user.id;
       }
     }
-    return this.conversationsService.getAllConversations(query);
+    return this.conversationsService.findAll(query);
   }
 
-  @Get(':param')
+  @Get(':id')
   @Roles(Permission.CUSTOMER, Permission.STORE_OWNER, Permission.SUPER_ADMIN)
   @ApiOperation({
     summary: 'Get conversation by ID',
     description: 'Retrieve conversation details by ID',
   })
-  @ApiParam({ name: 'param', description: 'Conversation ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Conversation ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Conversation retrieved successfully',
-    type: Conversation,
+    type: () => Conversation,
   })
   @ApiNotFoundResponse({ description: 'Conversation not found' })
-  getConversation(
-    @Param('param', ParseIntPipe) param: number,
+  @ApiForbiddenResponse({ description: 'Access denied to this conversation' })
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
     @CurrentUser() user: any,
   ): Promise<Conversation> {
-    return this.conversationsService.getConversation(param, user);
+    return this.conversationsService.findOne(id, user);
   }
 
   @Put(':id')
@@ -124,10 +124,10 @@ export class ConversationsController {
     summary: 'Update conversation',
     description: 'Update conversation information by ID',
   })
-  @ApiParam({ name: 'id', description: 'Conversation ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Conversation ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Conversation updated successfully',
-    type: Conversation,
+    type: () => Conversation,
   })
   @ApiNotFoundResponse({ description: 'Conversation not found' })
   @ApiBody({ type: UpdateConversationDto })
@@ -142,9 +142,9 @@ export class ConversationsController {
   @Roles(Permission.SUPER_ADMIN)
   @ApiOperation({
     summary: 'Delete conversation',
-    description: 'Permanently delete a conversation by ID (Admin only)',
+    description: 'Soft delete a conversation by ID (Admin only)',
   })
-  @ApiParam({ name: 'id', description: 'Conversation ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Conversation ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Conversation deleted successfully',
     type: CoreMutationOutput,
@@ -160,11 +160,13 @@ export class ConversationsController {
     summary: 'Mark conversation as read',
     description: 'Mark conversation as read for the current user',
   })
-  @ApiParam({ name: 'id', description: 'Conversation ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Conversation ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Conversation marked as read',
-    type: Conversation,
+    type: () => Conversation,
   })
+  @ApiNotFoundResponse({ description: 'Conversation not found' })
+  @ApiForbiddenResponse({ description: 'Access denied to this conversation' })
   markAsRead(
     @Param('id', ParseIntPipe) id: number,
     @CurrentUser() user: any,

--- a/api/rest/src/conversations/conversations.module.ts
+++ b/api/rest/src/conversations/conversations.module.ts
@@ -1,4 +1,3 @@
-// conversations/conversations.module.ts
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConversationsController } from './conversations.controller';

--- a/api/rest/src/conversations/conversations.service.ts
+++ b/api/rest/src/conversations/conversations.service.ts
@@ -1,12 +1,11 @@
-// conversations/conversations.service.ts
 import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Like } from 'typeorm';
-import { plainToClass } from 'class-transformer';
+import { Repository } from 'typeorm';
 import { CreateConversationDto } from './dto/create-conversation.dto';
 import { UpdateConversationDto } from './dto/update-conversation.dto';
 import {
@@ -17,7 +16,9 @@ import { Conversation } from './entities/conversation.entity';
 import { LatestMessage } from './entities/latest-message.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { paginate } from 'src/common/pagination/paginate';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
+import { SortOrder, Permission } from '../common/enums/enums';
+import { ConversationOrderByColumn } from 'src/common/enums/conversation-order-by.enum';
+
 
 @Injectable()
 export class ConversationsService {
@@ -28,10 +29,7 @@ export class ConversationsService {
     private latestMessageRepository: Repository<LatestMessage>,
   ) {}
 
-  async create(
-    createConversationDto: CreateConversationDto,
-  ): Promise<Conversation> {
-    // Check if conversation already exists between user and shop
+  async create(createConversationDto: CreateConversationDto): Promise<Conversation> {
     const existing = await this.conversationRepository.findOne({
       where: {
         user_id: createConversationDto.user_id.toString(),
@@ -43,18 +41,14 @@ export class ConversationsService {
       return existing;
     }
 
-    // Create conversation
     const conversation = this.conversationRepository.create({
       user_id: createConversationDto.user_id.toString(),
       shop_id: createConversationDto.shop_id,
       unseen: true,
     });
 
-    const savedConversation = await this.conversationRepository.save(
-      conversation,
-    );
+    const savedConversation = await this.conversationRepository.save(conversation);
 
-    // If initial message provided, create latest message
     if (createConversationDto.message) {
       const latestMessage = this.latestMessageRepository.create({
         body: createConversationDto.message,
@@ -62,30 +56,29 @@ export class ConversationsService {
         user_id: createConversationDto.user_id.toString(),
       });
 
-      const savedMessage = await this.latestMessageRepository.save(
-        latestMessage,
-      );
+      const savedMessage = await this.latestMessageRepository.save(latestMessage);
 
       savedConversation.latest_message = savedMessage;
       savedConversation.latest_message_id = savedMessage.id;
       await this.conversationRepository.save(savedConversation);
     }
 
-    return this.findOne(savedConversation.id);
+    return this.findOneById(savedConversation.id);
   }
 
-  async getAllConversations({
+  async findAll({
     page = 1,
     limit = 30,
     search,
     user_id,
     shop_id,
-    sortedBy = SortOrder.DESC, // Fix: Use enum instead of string literal
+    unseen,
+    orderBy = ConversationOrderByColumn.UPDATED_AT,
+    sortedBy = SortOrder.DESC,
   }: GetConversationsDto): Promise<ConversationPaginator> {
     const queryBuilder = this.conversationRepository
       .createQueryBuilder('conversation')
       .leftJoinAndSelect('conversation.user', 'user')
-      .leftJoinAndSelect('conversation.shop', 'shop')
       .leftJoinAndSelect('conversation.latest_message', 'latest_message');
 
     if (user_id) {
@@ -98,16 +91,38 @@ export class ConversationsService {
       queryBuilder.andWhere('conversation.shop_id = :shop_id', { shop_id });
     }
 
+    if (unseen !== undefined) {
+      queryBuilder.andWhere('conversation.unseen = :unseen', { unseen });
+    }
+
     if (search) {
       queryBuilder.andWhere(
-        '(user.name LIKE :search OR shop.name LIKE :search OR latest_message.body LIKE :search)',
+        '(user.name LIKE :search OR latest_message.body LIKE :search)',
         { search: `%${search}%` },
       );
     }
 
-    // Fix: Convert SortOrder enum to string literal for TypeORM
+    let orderColumn: string;
+    switch (orderBy) {
+      case ConversationOrderByColumn.USER_ID:
+        orderColumn = 'conversation.user_id';
+        break;
+      case ConversationOrderByColumn.SHOP_ID:
+        orderColumn = 'conversation.shop_id';
+        break;
+      case ConversationOrderByColumn.UNSEEN:
+        orderColumn = 'conversation.unseen';
+        break;
+      case ConversationOrderByColumn.CREATED_AT:
+        orderColumn = 'conversation.created_at';
+        break;
+      default:
+        orderColumn = 'conversation.updated_at';
+    }
+
     const orderDirection = sortedBy === SortOrder.ASC ? 'ASC' : 'DESC';
-    queryBuilder.orderBy('conversation.updated_at', orderDirection);
+    queryBuilder.orderBy(orderColumn, orderDirection);
+
     queryBuilder.skip((page - 1) * limit).take(limit);
 
     const [data, total] = await queryBuilder.getManyAndCount();
@@ -127,28 +142,25 @@ export class ConversationsService {
     };
   }
 
-  async getConversation(param: number, user?: any): Promise<Conversation> {
-    const conversation = await this.findOne(param);
+  async findOne(id: number, user?: any): Promise<Conversation> {
+    const conversation = await this.findOneById(id);
 
-    // Check permissions
-    if (user && !user?.permissions?.includes('super_admin')) {
-      if (
-        conversation.user_id !== user.id.toString() &&
-        conversation.shop_id !== user.shop_id
-      ) {
-        throw new BadRequestException(
-          'You do not have permission to view this conversation',
-        );
+    if (user && !user?.permissions?.includes(Permission.SUPER_ADMIN)) {
+      const userId = user.id?.toString();
+      const shopId = user.shop_id;
+      
+      if (conversation.user_id !== userId && conversation.shop_id !== shopId) {
+        throw new ForbiddenException('You do not have permission to view this conversation');
       }
     }
 
     return conversation;
   }
 
-  async findOne(id: number): Promise<Conversation> {
+  async findOneById(id: number): Promise<Conversation> {
     const conversation = await this.conversationRepository.findOne({
       where: { id },
-      relations: ['user', 'shop', 'latest_message'],
+      relations: ['user', 'latest_message'],
     });
 
     if (!conversation) {
@@ -158,28 +170,28 @@ export class ConversationsService {
     return conversation;
   }
 
-  async update(
-    id: number,
-    updateConversationDto: UpdateConversationDto,
-  ): Promise<Conversation> {
-    const conversation = await this.findOne(id);
+  async update(id: number, updateConversationDto: UpdateConversationDto): Promise<Conversation> {
+    const conversation = await this.findOneById(id);
 
     if (updateConversationDto.shop_id !== undefined) {
       conversation.shop_id = updateConversationDto.shop_id;
+    }
+
+    if (updateConversationDto.user_id !== undefined) {
+      conversation.user_id = updateConversationDto.user_id.toString();
     }
 
     return this.conversationRepository.save(conversation);
   }
 
   async remove(id: number): Promise<CoreMutationOutput> {
-    const conversation = await this.findOne(id);
+    const conversation = await this.findOneById(id);
 
-    // Delete associated latest message
     if (conversation.latest_message) {
-      await this.latestMessageRepository.remove(conversation.latest_message);
+      await this.latestMessageRepository.softDelete(conversation.latest_message.id);
     }
 
-    await this.conversationRepository.remove(conversation);
+    await this.conversationRepository.softDelete(id);
 
     return {
       success: true,
@@ -188,20 +200,17 @@ export class ConversationsService {
   }
 
   async markAsRead(id: number, user: any): Promise<Conversation> {
-    const conversation = await this.findOne(id);
+    const conversation = await this.findOneById(id);
 
-    // Only mark as read if user is part of the conversation
-    if (
-      conversation.user_id === user.id.toString() ||
-      conversation.shop_id === user.shop_id
-    ) {
+    const userId = user.id?.toString();
+    const shopId = user.shop_id;
+
+    if (conversation.user_id === userId || conversation.shop_id === shopId) {
       conversation.unseen = false;
       return this.conversationRepository.save(conversation);
     }
 
-    throw new BadRequestException(
-      'You do not have permission to mark this conversation as read',
-    );
+    throw new ForbiddenException('You do not have permission to mark this conversation as read');
   }
 
   async addMessage(
@@ -209,9 +218,8 @@ export class ConversationsService {
     userId: number,
     message: string,
   ): Promise<Conversation> {
-    const conversation = await this.findOne(conversationId);
+    const conversation = await this.findOneById(conversationId);
 
-    // Create new latest message
     const latestMessage = this.latestMessageRepository.create({
       body: message,
       conversation_id: conversationId.toString(),
@@ -220,7 +228,6 @@ export class ConversationsService {
 
     const savedMessage = await this.latestMessageRepository.save(latestMessage);
 
-    // Update conversation
     conversation.latest_message = savedMessage;
     conversation.latest_message_id = savedMessage.id;
     conversation.unseen = true;

--- a/api/rest/src/conversations/dto/conversation-response.dto.ts
+++ b/api/rest/src/conversations/dto/conversation-response.dto.ts
@@ -1,14 +1,13 @@
-// conversations/dto/conversation-response.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { Conversation } from '../entities/conversation.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 
 export class ConversationResponse {
-  @ApiProperty({ type: Conversation })
+  @ApiProperty({ type: () => Conversation })
   conversation: Conversation;
 }
 
 export class ConversationMutationResponse extends CoreMutationOutput {
-  @ApiProperty({ type: Conversation, required: false })
+  @ApiProperty({ type: () => Conversation, required: false })
   conversation?: Conversation;
 }

--- a/api/rest/src/conversations/dto/create-conversation.dto.ts
+++ b/api/rest/src/conversations/dto/create-conversation.dto.ts
@@ -1,20 +1,32 @@
-// conversations/dto/create-conversation.dto.ts
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsNumber, IsNotEmpty, IsOptional, IsString } from 'class-validator';
-import { Conversation } from '../entities/conversation.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
 
-export class CreateConversationDto extends PickType(Conversation, [
-  'shop_id',
-] as const) {
-  @ApiProperty({ description: 'User ID', example: 1 })
+export class CreateConversationDto {
+  @ApiProperty({ 
+    description: 'User ID', 
+    example: 1,
+    type: Number,
+  })
   @IsNumber()
   @IsNotEmpty()
+  @Min(1)
   user_id: number;
+
+  @ApiProperty({ 
+    description: 'Shop ID', 
+    example: 7,
+    type: Number,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  @Min(1)
+  shop_id: number;
 
   @ApiProperty({
     description: 'Initial message',
     example: 'Hello, I have a question',
     required: false,
+    type: String,
   })
   @IsString()
   @IsOptional()

--- a/api/rest/src/conversations/dto/get-conversations.dto.ts
+++ b/api/rest/src/conversations/dto/get-conversations.dto.ts
@@ -1,60 +1,108 @@
-// conversations/dto/get-conversations.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
 import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
+import { IsOptional, IsString, IsNumber, IsEnum, IsBoolean } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SortOrder } from 'src/common/enums/enums';
+import { ConversationOrderByColumn } from 'src/common/enums/conversation-order-by.enum';
 import { Conversation } from '../entities/conversation.entity';
 
+
 export class ConversationPaginator {
-  @ApiProperty({ type: [Conversation] })
+  @ApiProperty({ type: () => [Conversation] })
   data: Conversation[];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number })
   current_page: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number })
   per_page: number;
 
-  @ApiProperty({ example: 100 })
+  @ApiProperty({ example: 100, type: Number })
   total: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number })
   last_page: number;
 
-  @ApiProperty({ example: '/conversations?page=1' })
+  @ApiProperty({ example: '/conversations?page=1', type: String })
   first_page_url: string;
 
-  @ApiProperty({ example: '/conversations?page=10' })
+  @ApiProperty({ example: '/conversations?page=10', type: String })
   last_page_url: string;
 
-  @ApiProperty({ example: '/conversations?page=2', nullable: true })
+  @ApiProperty({ example: '/conversations?page=2', nullable: true, type: String })
   next_page_url: string | null;
 
-  @ApiProperty({ example: '/conversations?page=1', nullable: true })
+  @ApiProperty({ example: '/conversations?page=1', nullable: true, type: String })
   prev_page_url: string | null;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number })
   from: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number })
   to: number;
 }
 
 export class GetConversationsDto extends PaginationArgs {
-  @ApiProperty({ required: false })
-  orderBy?: string;
+  @ApiProperty({ 
+    enum: ConversationOrderByColumn, 
+    required: false, 
+    default: ConversationOrderByColumn.UPDATED_AT,
+    description: 'Column to order by',
+  })
+  @IsOptional()
+  @IsEnum(ConversationOrderByColumn)
+  orderBy?: ConversationOrderByColumn = ConversationOrderByColumn.UPDATED_AT;
 
-  @ApiProperty({ enum: SortOrder, required: false, default: SortOrder.DESC })
-  sortedBy?: SortOrder;
+  @ApiProperty({ 
+    enum: SortOrder, 
+    required: false, 
+    default: SortOrder.DESC,
+    description: 'Sort direction',
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortedBy?: SortOrder = SortOrder.DESC;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ 
+    required: false, 
+    type: String,
+    description: 'Search term',
+    example: 'question',
+  })
+  @IsOptional()
+  @IsString()
   search?: string;
 
-  @ApiProperty({ required: false, default: 'en' })
-  language?: string;
-
-  @ApiProperty({ required: false })
+  @ApiProperty({ 
+    required: false, 
+    type: Number,
+    description: 'Filter by user ID',
+    example: 6,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   user_id?: number;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ 
+    required: false, 
+    type: Number,
+    description: 'Filter by shop ID',
+    example: 7,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   shop_id?: number;
+
+  @ApiProperty({ 
+    required: false, 
+    type: Boolean,
+    description: 'Filter by unseen status',
+    example: false,
+  })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  unseen?: boolean;
 }

--- a/api/rest/src/conversations/dto/update-conversation.dto.ts
+++ b/api/rest/src/conversations/dto/update-conversation.dto.ts
@@ -1,4 +1,3 @@
-// conversations/dto/update-conversation.dto.ts
 import { PartialType } from '@nestjs/swagger';
 import { CreateConversationDto } from './create-conversation.dto';
 

--- a/api/rest/src/conversations/entities/conversation.entity.ts
+++ b/api/rest/src/conversations/entities/conversation.entity.ts
@@ -1,64 +1,60 @@
-// conversations/entities/conversation.entity.ts
 import {
   Entity,
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   ManyToOne,
   OneToOne,
   JoinColumn,
 } from 'typeorm';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { CoreEntity } from '../../common/entities/core.entity';
-// Comment out Shop import temporarily
-// import { Shop } from '../../shops/entities/shop.entity';
 import { User } from '../../users/entities/user.entity';
 import { LatestMessage } from './latest-message.entity';
 
 @Entity('conversations')
 export class Conversation extends CoreEntity {
-  @ApiProperty({ description: 'Conversation ID', example: 1 })
+  @ApiProperty({ description: 'Conversation ID', example: 1, type: Number })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ApiProperty({ description: 'Shop ID', example: 7 })
+  @ApiProperty({ description: 'Shop ID', example: 7, type: Number })
   @Column()
   shop_id: number;
 
-  @ApiProperty({ description: 'User ID', example: '6' })
+  @ApiProperty({ description: 'User ID', example: '6', type: String })
   @Column()
   user_id: string;
 
-  @ApiProperty({ description: 'Unseen status', example: false })
+  @ApiProperty({ description: 'Unseen status', example: false, type: Boolean })
   @Column({ default: false })
   unseen: boolean;
+
+  @ApiProperty({ description: 'Latest message ID', required: false, type: Number })
+  @Column({ nullable: true })
+  latest_message_id?: number;
 
   @ApiProperty({ type: () => User, description: 'User details' })
   @ManyToOne(() => User)
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  // Comment out Shop relation temporarily
-  // @ApiProperty({ type: () => Shop, description: 'Shop details' })
-  // @ManyToOne(() => Shop)
-  // @JoinColumn({ name: 'shop_id' })
-  // shop: Shop;
-
   @ApiProperty({ type: () => LatestMessage, description: 'Latest message' })
   @OneToOne(() => LatestMessage)
   @JoinColumn({ name: 'latest_message_id' })
   latest_message: LatestMessage;
 
-  @ApiProperty({ description: 'Latest message ID', required: false })
-  @Column({ nullable: true })
-  latest_message_id?: number;
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
 
-  @ApiProperty({ description: 'Creation timestamp' })
+  @ApiProperty({ description: 'Creation timestamp', type: Date })
   @CreateDateColumn()
   created_at: Date;
 
-  @ApiProperty({ description: 'Last update timestamp' })
+  @ApiProperty({ description: 'Last update timestamp', type: Date })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/api/rest/src/conversations/entities/latest-message.entity.ts
+++ b/api/rest/src/conversations/entities/latest-message.entity.ts
@@ -1,40 +1,53 @@
-// conversations/entities/latest-message.entity.ts
 import {
   Entity,
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { CoreEntity } from '../../common/entities/core.entity';
 
 @Entity('latest_messages')
 export class LatestMessage extends CoreEntity {
-  @ApiProperty({ description: 'Latest message ID', example: 1 })
+  @ApiProperty({ description: 'Latest message ID', example: 1, type: Number })
   @PrimaryGeneratedColumn()
   id: number;
 
   @ApiProperty({
     description: 'Message body',
     example: 'Hello, I have a question',
+    type: String,
   })
   @Column('text')
   body: string;
 
-  @ApiProperty({ description: 'Conversation ID', example: '1' })
+  @ApiProperty({ 
+    description: 'Conversation ID', 
+    example: '1',
+    type: String,
+  })
   @Column()
   conversation_id: string;
 
-  @ApiProperty({ description: 'User ID', example: '1' })
+  @ApiProperty({ 
+    description: 'User ID', 
+    example: '1',
+    type: String,
+  })
   @Column()
   user_id: string;
 
-  @ApiProperty({ description: 'Creation timestamp' })
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
+
+  @ApiProperty({ description: 'Creation timestamp', type: Date })
   @CreateDateColumn()
   created_at: Date;
 
-  @ApiProperty({ description: 'Last update timestamp' })
+  @ApiProperty({ description: 'Last update timestamp', type: Date })
   @UpdateDateColumn()
   updated_at: Date;
 }


### PR DESCRIPTION
Refactor and enhance the conversations feature: added ConversationOrderByColumn enum and richer DTO validation (ordering, unseen filter, typed pagination fields). Controller methods and Swagger docs were cleaned up (renamed endpoints, improved response typing, param examples, added forbidden responses, expanded role access), and controller now delegates to updated service method names.

Service was refactored: renamed list/get helpers (findAll, findOneById, findOne), added ordering by multiple columns, unseen filtering, stricter permission checks using Permission enum and ForbiddenException, convert user_id types where needed, and switched to softDelete for conversations and latest messages. Entities and DTOs updated with explicit ApiProperty types, soft-delete columns (deleted_at), and other small schema/serialization fixes.