### PR TITLE
feat: categories API: ordering & soft-delete

### DIFF
--- a/api/rest/src/categories/categories.controller.ts
+++ b/api/rest/src/categories/categories.controller.ts
@@ -1,4 +1,3 @@
-// categories/categories.controller.ts
 import {
   Controller,
   Get,
@@ -14,7 +13,6 @@ import {
 import {
   ApiTags,
   ApiOperation,
-  ApiResponse,
   ApiBearerAuth,
   ApiBody,
   ApiParam,
@@ -34,9 +32,10 @@ import { Category } from './entities/category.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
-import { Permission } from '../common/enums/enums';
+import { Permission, SortOrder } from '../common/enums/enums';
 import { Roles } from '../common/decorators/roles.decorator';
 import { Public } from '../common/decorators/public.decorator';
+
 
 @ApiTags('📁 Categories')
 @Controller('categories')
@@ -53,7 +52,7 @@ export class CategoriesController {
   })
   @ApiCreatedResponse({
     description: 'Category created successfully',
-    type: Category,
+    type: () => Category,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
@@ -73,11 +72,8 @@ export class CategoriesController {
     description: 'Categories retrieved successfully',
     type: CategoryPaginator,
   })
-  @ApiQuery({ name: 'search', required: false })
-  @ApiQuery({ name: 'parent', required: false })
-  @ApiQuery({ name: 'language', required: false })
   findAll(@Query() query: GetCategoriesDto): Promise<CategoryPaginator> {
-    return this.categoriesService.getCategories(query);
+    return this.categoriesService.findAll(query);
   }
 
   @Get(':param')
@@ -90,18 +86,18 @@ export class CategoriesController {
     name: 'param',
     description: 'Category ID or slug',
     example: '1 or fruits-vegetables',
+    type: String,
   })
   @ApiOkResponse({
     description: 'Category retrieved successfully',
-    type: Category,
+    type: () => Category,
   })
   @ApiNotFoundResponse({ description: 'Category not found' })
-  @ApiQuery({ name: 'language', required: false })
   findOne(
     @Param('param') param: string,
-    @Query('language') language: string,
+    @Query('language') language?: string,
   ): Promise<Category> {
-    return this.categoriesService.getCategory(param, language);
+    return this.categoriesService.findOne(param, language);
   }
 
   @Put(':id')
@@ -110,10 +106,10 @@ export class CategoriesController {
     summary: 'Update category',
     description: 'Update category information by ID (Admin/Store Owner only)',
   })
-  @ApiParam({ name: 'id', description: 'Category ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Category ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Category updated successfully',
-    type: Category,
+    type: () => Category,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiNotFoundResponse({ description: 'Category not found' })
@@ -129,14 +125,15 @@ export class CategoriesController {
   @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER)
   @ApiOperation({
     summary: 'Delete category',
-    description: 'Permanently delete a category by ID (Admin/Store Owner only)',
+    description: 'Soft delete a category by ID (Admin/Store Owner only)',
   })
-  @ApiParam({ name: 'id', description: 'Category ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Category ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Category deleted successfully',
     type: CoreMutationOutput,
   })
   @ApiNotFoundResponse({ description: 'Category not found' })
+  @ApiForbiddenResponse({ description: 'Cannot delete category with subcategories' })
   remove(@Param('id', ParseIntPipe) id: number): Promise<CoreMutationOutput> {
     return this.categoriesService.remove(id);
   }

--- a/api/rest/src/categories/categories.module.ts
+++ b/api/rest/src/categories/categories.module.ts
@@ -1,4 +1,3 @@
-// categories/categories.module.ts
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CategoriesService } from './categories.service';

--- a/api/rest/src/categories/categories.service.ts
+++ b/api/rest/src/categories/categories.service.ts
@@ -14,8 +14,9 @@ import { UpdateCategoryDto } from './dto/update-category.dto';
 import { Category } from './entities/category.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { paginate } from 'src/common/pagination/paginate';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
-import { QueryCategoriesOrderByColumn } from '../common/enums/enums';
+import { SortOrder } from 'src/common/enums/enums';
+import { CategoryOrderByColumn } from 'src/common/enums/category-type.enum';
+
 
 @Injectable()
 export class CategoriesService {
@@ -25,10 +26,8 @@ export class CategoriesService {
   ) {}
 
   async create(createCategoryDto: CreateCategoryDto): Promise<Category> {
-    // Generate slug from name
     const slug = this.generateSlug(createCategoryDto.name);
 
-    // Check if category with same slug exists
     const existing = await this.categoryRepository.findOne({
       where: { slug },
     });
@@ -37,58 +36,52 @@ export class CategoriesService {
       throw new ConflictException('Category with this name already exists');
     }
 
-    // Create a new category instance
-    const category = new Category();
+    const categoryData: Partial<Category> = {
+      name: createCategoryDto.name,
+      slug: slug,
+      details: createCategoryDto.details,
+      icon: createCategoryDto.icon,
+      image: createCategoryDto.image,
+      type_id: createCategoryDto.type_id,
+      language: createCategoryDto.language || 'en',
+      translated_languages: [createCategoryDto.language || 'en'],
+    };
 
-    // Manually assign all properties
-    category.name = createCategoryDto.name;
-    category.slug = slug;
-    category.details = createCategoryDto.details;
-    category.icon = createCategoryDto.icon;
-    category.image = createCategoryDto.image;
-    category.type_id = createCategoryDto.type_id;
-    category.language = createCategoryDto.language || 'en';
-    category.translated_languages = [createCategoryDto.language || 'en'];
-
-    // Set parent_id directly if provided
     if (createCategoryDto.parent) {
-      category.parent_id = createCategoryDto.parent;
+      categoryData.parent_id = createCategoryDto.parent;
     }
 
+    const category = this.categoryRepository.create(categoryData);
     return this.categoryRepository.save(category);
   }
 
-  async getCategories({
+  async findAll({
     page = 1,
     limit = 30,
     search,
     parent,
     language,
     type_id,
-    orderBy = QueryCategoriesOrderByColumn.CREATED_AT,
+    orderBy = CategoryOrderByColumn.CREATED_AT,
     sortedBy = SortOrder.DESC,
   }: GetCategoriesDto): Promise<CategoryPaginator> {
     const queryBuilder = this.categoryRepository
       .createQueryBuilder('category')
-      .leftJoinAndSelect('category.parent', 'parent')
-      .leftJoinAndSelect('category.children', 'children')
-      .leftJoinAndSelect('category.type', 'type');
+      .leftJoinAndSelect('category.parent', 'parent');
 
     if (search) {
       queryBuilder.andWhere(
         '(category.name LIKE :search OR category.details LIKE :search)',
-        {
-          search: `%${search}%`,
-        },
+        { search: `%${search}%` },
       );
     }
 
-    if (parent !== undefined) {
-      if (parent === 'null') {
+    if (parent !== undefined && parent !== null) {
+      if (parent === 0 || parent === null) {
         queryBuilder.andWhere('category.parent_id IS NULL');
       } else {
         queryBuilder.andWhere('category.parent_id = :parent', {
-          parent: Number(parent),
+          parent: parent,
         });
       }
     }
@@ -104,12 +97,16 @@ export class CategoriesService {
       queryBuilder.andWhere('category.type_id = :type_id', { type_id });
     }
 
-    // Apply ordering
-    let orderColumn = 'category.created_at';
-    if (orderBy === QueryCategoriesOrderByColumn.NAME) {
-      orderColumn = 'category.name';
-    } else if (orderBy === QueryCategoriesOrderByColumn.UPDATED_AT) {
-      orderColumn = 'category.updated_at';
+    let orderColumn: string;
+    switch (orderBy) {
+      case CategoryOrderByColumn.NAME:
+        orderColumn = 'category.name';
+        break;
+      case CategoryOrderByColumn.UPDATED_AT:
+        orderColumn = 'category.updated_at';
+        break;
+      default:
+        orderColumn = 'category.created_at';
     }
 
     const orderDirection = sortedBy === SortOrder.ASC ? 'ASC' : 'DESC';
@@ -119,55 +116,30 @@ export class CategoriesService {
 
     const [data, total] = await queryBuilder.getManyAndCount();
 
-    // TODO: Uncomment this when Product module is developed
-    // Calculate products count for each category
-    // for (const category of data) {
-    //   if (category.children && category.children.length > 0) {
-    //     // For parent categories, sum products from all children
-    //     let totalProducts = 0;
-    //     for (const child of category.children) {
-    //       const childWithProducts = await this.categoryRepository.findOne({
-    //         where: { id: child.id },
-    //         relations: ['products'],
-    //       });
-    //       totalProducts += childWithProducts?.products?.length || 0;
-    //     }
-    //     category.products_count = totalProducts;
-    //   } else {
-    //     // For leaf categories, get direct products count
-    //     const categoryWithProducts = await this.categoryRepository.findOne({
-    //       where: { id: category.id },
-    //       relations: ['products'],
-    //     });
-    //     category.products_count = categoryWithProducts?.products?.length || 0;
-    //   }
-    // }
-
     const url = `/categories?limit=${limit}`;
     const paginationInfo = paginate(total, page, limit, data.length, url);
 
-    // Calculate from and to values
     const from = (page - 1) * limit + 1;
     const to = Math.min(page * limit, total);
 
     return {
       data,
       ...paginationInfo,
+      current_page: page,
+      per_page: limit,
+      total,
+      last_page: Math.ceil(total / limit),
       from,
       to,
     };
   }
 
-  async getCategory(param: string, language?: string): Promise<Category> {
+  async findOne(param: string, language?: string): Promise<Category> {
     const isId = !isNaN(Number(param));
 
     const queryBuilder = this.categoryRepository
       .createQueryBuilder('category')
-      .leftJoinAndSelect('category.parent', 'parent')
-      .leftJoinAndSelect('category.children', 'children')
-      .leftJoinAndSelect('category.type', 'type');
-    // TODO: Uncomment this when Product module is developed
-    // .leftJoinAndSelect('category.products', 'products')
+      .leftJoinAndSelect('category.parent', 'parent');
 
     if (isId) {
       queryBuilder.where('category.id = :id', { id: Number(param) });
@@ -190,27 +162,18 @@ export class CategoriesService {
       );
     }
 
-    // TODO: Uncomment this when Product module is developed
-    // Set products count
-    // category.products_count = category.products?.length || 0;
-
     return category;
   }
 
-  async update(
-    id: number,
-    updateCategoryDto: UpdateCategoryDto,
-  ): Promise<Category> {
+  async update(id: number, updateCategoryDto: UpdateCategoryDto): Promise<Category> {
     const category = await this.categoryRepository.findOne({
       where: { id },
-      relations: ['parent', 'children', 'type'],
     });
 
     if (!category) {
       throw new NotFoundException(`Category with ID ${id} not found`);
     }
 
-    // Update fields
     if (updateCategoryDto.name) {
       category.name = updateCategoryDto.name;
       category.slug = this.generateSlug(updateCategoryDto.name);
@@ -249,25 +212,18 @@ export class CategoriesService {
   async remove(id: number): Promise<CoreMutationOutput> {
     const category = await this.categoryRepository.findOne({
       where: { id },
-      relations: ['children'], // Removed 'products' temporarily
+      relations: ['children'],
     });
 
     if (!category) {
       throw new NotFoundException(`Category with ID ${id} not found`);
     }
 
-    // Check if category has children
     if (category.children && category.children.length > 0) {
       throw new ConflictException('Cannot delete category with subcategories');
     }
 
-    // TODO: Uncomment this when Product module is developed
-    // Check if category has products
-    // if (category.products && category.products.length > 0) {
-    //   throw new ConflictException('Cannot delete category with products');
-    // }
-
-    await this.categoryRepository.remove(category);
+    await this.categoryRepository.softDelete(id);
 
     return {
       success: true,

--- a/api/rest/src/categories/dto/create-category.dto.ts
+++ b/api/rest/src/categories/dto/create-category.dto.ts
@@ -1,34 +1,71 @@
-// categories/dto/create-category.dto.ts
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import {
-  IsString,
-  IsOptional,
-  IsNumber,
-  IsObject,
-  ValidateNested,
-} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { Category } from '../entities/category.entity';
+import { IsNumber, IsObject, IsOptional, IsString } from 'class-validator';
 import { Attachment } from '../../common/entities/attachment.entity';
 
-export class CreateCategoryDto extends PickType(Category, [
-  'name',
-  'details',
-  'icon',
-  'language',
-] as const) {
-  @ApiProperty({ type: Attachment, required: false })
-  @ValidateNested()
-  @Type(() => Attachment)
+export class CreateCategoryDto {
+  @ApiProperty({
+    description: 'Category name',
+    example: 'Fruits & Vegetables',
+    type: String,
+  })
+  @IsString()
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Category details',
+    example: 'Fresh produce and vegetables',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  details?: string;
+
+  @ApiPropertyOptional({
+    description: 'Category icon',
+    example: 'fruits-vegetables',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  icon?: string;
+
+  @ApiPropertyOptional({
+    description: 'Language code',
+    example: 'en',
+    default: 'en',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  language?: string = 'en';
+
+  @ApiPropertyOptional({
+    type: Attachment,
+    required: false,
+    description: 'Category image',
+  })
+  @IsObject()
   @IsOptional()
   image?: Attachment;
 
-  @ApiProperty({ description: 'Parent category ID', required: false })
+  @ApiPropertyOptional({
+    description: 'Parent category ID',
+    type: Number,
+    example: 1,
+  })
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   parent?: number;
 
-  @ApiProperty({ description: 'Type ID', required: true })
+  @ApiProperty({
+    description: 'Type ID',
+    required: true,
+    type: Number,
+    example: 1,
+  })
+  @Type(() => Number)
   @IsNumber()
   type_id: number;
 }

--- a/api/rest/src/categories/dto/get-categories.dto.ts
+++ b/api/rest/src/categories/dto/get-categories.dto.ts
@@ -1,61 +1,107 @@
-// categories/dto/get-categories.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
 import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
+import { IsOptional, IsString, IsNumber, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SortOrder } from 'src/common/enums/enums';
 import { Category } from '../entities/category.entity';
-import { QueryCategoriesOrderByColumn } from '../../common/enums/enums';
+import { CategoryOrderByColumn } from 'src/common/enums/category-type.enum';
 
 export class CategoryPaginator {
-  @ApiProperty({ type: [Category] })
+  @ApiProperty({ type: () => [Category] })
   data: Category[];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number })
   current_page: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number })
   per_page: number;
 
-  @ApiProperty({ example: 100 })
+  @ApiProperty({ example: 100, type: Number })
   total: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number })
   last_page: number;
 
-  @ApiProperty({ example: '/categories?page=1' })
+  @ApiProperty({ example: '/categories?page=1', type: String })
   first_page_url: string;
 
-  @ApiProperty({ example: '/categories?page=10' })
+  @ApiProperty({ example: '/categories?page=10', type: String })
   last_page_url: string;
 
-  @ApiProperty({ example: '/categories?page=2', nullable: true })
+  @ApiProperty({ example: '/categories?page=2', nullable: true, type: String })
   next_page_url: string | null;
 
-  @ApiProperty({ example: '/categories?page=1', nullable: true })
+  @ApiProperty({ example: '/categories?page=1', nullable: true, type: String })
   prev_page_url: string | null;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number })
   from: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number })
   to: number;
 }
 
 export class GetCategoriesDto extends PaginationArgs {
-  @ApiProperty({ enum: QueryCategoriesOrderByColumn, required: false })
-  orderBy?: QueryCategoriesOrderByColumn;
+  @ApiProperty({ 
+    enum: CategoryOrderByColumn, 
+    required: false, 
+    default: CategoryOrderByColumn.CREATED_AT,
+    description: 'Column to order by',
+  })
+  @IsOptional()
+  @IsEnum(CategoryOrderByColumn)
+  orderBy?: CategoryOrderByColumn = CategoryOrderByColumn.CREATED_AT;
 
-  @ApiProperty({ enum: SortOrder, required: false, default: SortOrder.DESC })
-  sortedBy?: SortOrder;
+  @ApiProperty({ 
+    enum: SortOrder, 
+    required: false, 
+    default: SortOrder.DESC,
+    description: 'Sort direction',
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortedBy?: SortOrder = SortOrder.DESC;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ 
+    required: false, 
+    type: String,
+    description: 'Search term',
+    example: 'Fruits',
+  })
+  @IsOptional()
+  @IsString()
   search?: string;
 
-  @ApiProperty({ required: false, default: 'null' })
-  parent?: number | string;
+  @ApiProperty({ 
+    required: false, 
+    type: Number,
+    description: 'Parent category ID',
+    example: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  parent?: number;
 
-  @ApiProperty({ required: false, default: 'en' })
-  language?: string;
+  @ApiProperty({ 
+    required: false, 
+    default: 'en',
+    type: String,
+    description: 'Language code',
+    example: 'en',
+  })
+  @IsOptional()
+  @IsString()
+  language?: string = 'en';
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ 
+    required: false, 
+    type: Number,
+    description: 'Type ID',
+    example: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   type_id?: number;
 }

--- a/api/rest/src/categories/dto/update-category.dto.ts
+++ b/api/rest/src/categories/dto/update-category.dto.ts
@@ -1,4 +1,3 @@
-// categories/dto/update-category.dto.ts
 import { PartialType } from '@nestjs/swagger';
 import { CreateCategoryDto } from './create-category.dto';
 

--- a/api/rest/src/categories/entities/category.entity.ts
+++ b/api/rest/src/categories/entities/category.entity.ts
@@ -4,56 +4,62 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   ManyToOne,
   OneToMany,
   JoinColumn,
 } from 'typeorm';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { CoreEntity } from '../../common/entities/core.entity';
 import { Attachment } from '../../common/entities/attachment.entity';
-// TODO: Uncomment when Type module is developed
-// import { Type } from '../../types/entities/type.entity';
-// TODO: Uncomment when Product module is developed
-// import { Product } from '../../products/entities/product.entity';
 
 @Entity('categories')
 export class Category extends CoreEntity {
-  @ApiProperty({ description: 'Category ID', example: 1 })
+  @ApiProperty({ description: 'Category ID', example: 1, type: Number })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ApiProperty({ description: 'Category name', example: 'Fruits & Vegetables' })
+  @ApiProperty({ 
+    description: 'Category name', 
+    example: 'Fruits & Vegetables',
+    type: String,
+  })
   @Column()
   name: string;
 
-  @ApiProperty({ description: 'Category slug', example: 'fruits-vegetables' })
+  @ApiProperty({ 
+    description: 'Category slug', 
+    example: 'fruits-vegetables',
+    type: String,
+  })
   @Column({ unique: true })
   slug: string;
 
-  @ApiProperty({
-    type: () => Category,
-    description: 'Parent category',
-    required: false,
-  })
+  @ApiHideProperty()
   @ManyToOne(() => Category, (category) => category.children, {
     nullable: true,
   })
   @JoinColumn({ name: 'parent_id' })
   parent?: Category;
 
-  @ApiProperty({ description: 'Parent category ID', required: false })
+  @ApiProperty({ 
+    description: 'Parent category ID', 
+    required: false,
+    type: Number,
+    example: 1,
+  })
   @Column({ nullable: true })
   parent_id?: number;
 
-  @ApiProperty({
-    type: () => [Category],
-    description: 'Child categories',
-    required: false,
-  })
+  @ApiHideProperty()
   @OneToMany(() => Category, (category) => category.parent)
   children?: Category[];
 
-  @ApiProperty({ description: 'Category details', required: false })
+  @ApiProperty({ 
+    description: 'Category details', 
+    required: false,
+    type: String,
+  })
   @Column('text', { nullable: true })
   details?: string;
 
@@ -65,44 +71,55 @@ export class Category extends CoreEntity {
   @Column('json', { nullable: true })
   image?: Attachment;
 
-  @ApiProperty({ description: 'Category icon', required: false })
+  @ApiProperty({ 
+    description: 'Category icon', 
+    required: false,
+    type: String,
+  })
   @Column({ nullable: true })
   icon?: string;
 
-  // TODO: Uncomment when Type module is developed
-  // @ApiProperty({ type: () => Type, description: 'Category type' })
-  // @ManyToOne(() => Type)
-  // @JoinColumn({ name: 'type_id' })
-  // type?: Type;
-
-  @ApiProperty({ description: 'Type ID', example: 1 })
+  @ApiProperty({ 
+    description: 'Type ID', 
+    example: 1,
+    type: Number,
+  })
   @Column()
   type_id: number;
 
-  // TODO: Uncomment when Product module is developed
-  // @ApiProperty({
-  //   type: () => [Product],
-  //   description: 'Products in this category',
-  // })
-  // @OneToMany(() => Product, (product) => product.category)
-  // products?: Product[];
-
-  @ApiProperty({ description: 'Language code', default: 'en' })
+  @ApiProperty({ 
+    description: 'Language code', 
+    default: 'en',
+    type: String,
+  })
   @Column({ default: 'en' })
   language: string;
 
-  @ApiProperty({ description: 'Translated languages', type: [String] })
+  @ApiProperty({ 
+    description: 'Translated languages', 
+    type: [String],
+    example: ['en', 'es', 'fr'],
+  })
   @Column('simple-array', { nullable: true })
   translated_languages: string[];
 
-  @ApiProperty({ description: 'Products count', required: false })
+  @ApiProperty({ 
+    description: 'Products count', 
+    required: false,
+    type: Number,
+    example: 42,
+  })
   products_count?: number;
 
-  @ApiProperty({ description: 'Creation timestamp' })
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
+
+  @ApiProperty({ description: 'Creation timestamp', type: Date })
   @CreateDateColumn()
   created_at: Date;
 
-  @ApiProperty({ description: 'Last update timestamp' })
+  @ApiProperty({ description: 'Last update timestamp', type: Date })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/api/rest/src/common/enums/category-type.enum.ts
+++ b/api/rest/src/common/enums/category-type.enum.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum CategoryOrderByColumn {
+  CREATED_AT = 'created_at',
+  UPDATED_AT = 'updated_at',
+  NAME = 'name',
+}


### PR DESCRIPTION
Large refactor of the Categories module:
- Controller: improved Swagger metadata, renamed endpoints to call service.findAll/findOne, made language query optional, added examples and ApiForbiddenResponse for delete.
- Service: renamed getCategories/getCategory -> findAll/findOne; switched to repository.create for create, preserved slug generation and uniqueness check; improved parent handling, applied ordering via new CategoryOrderByColumn enum and SortOrder, updated pagination response shape, removed hard product-related logic, and replaced remove() with softDelete() (adds soft-delete behavior and child-check conflict).
- DTOs: replaced PickType-based CreateCategoryDto with explicit validated properties and proper Swagger decorators; enhanced GetCategoriesDto with ordering enums, validation, typed fields and defaults; Update DTO remains a PartialType of CreateCategoryDto.
- Entity: Category updated with DeleteDateColumn (deleted_at), improved ApiProperty types/examples, hid relational objects from Swagger, and added typed fields like products_count.
- New enum: added CategoryOrderByColumn to centralize order-by columns. Overall aims: better validation, clearer Swagger docs, ordering support, safer deletion via soft-delete, and cleaner service/controller separation.