### PR TITLE
feat: become-seller API and improve JWT extraction

### DIFF
--- a/api/rest/src/auth/strategies/jwt.strategy.ts
+++ b/api/rest/src/auth/strategies/jwt.strategy.ts
@@ -9,7 +9,16 @@ import { UsersService } from 'src/users/users.service';
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(private usersService: UsersService) {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      // Robust extractor: handles headers like "Bearer <token>" and
+      // accidental duplicates like "Bearer Bearer <token>" that some
+      // Swagger clients produce when the user pastes the full "Bearer <token>".
+      jwtFromRequest: (req: any) => {
+        const header = req?.headers?.authorization;
+        if (!header) return null;
+        // Remove all occurrences of the literal "Bearer" (case-insensitive)
+        // then trim to obtain the raw token value.
+        return header.replace(/Bearer\s+/gi, '').trim();
+      },
       ignoreExpiration: false,
       secretOrKey: jwtConfig.secret,
     });

--- a/api/rest/src/become-seller/become-seller.controller.ts
+++ b/api/rest/src/become-seller/become-seller.controller.ts
@@ -1,4 +1,3 @@
-// become-seller/become-seller.controller.ts
 import {
   Body,
   Controller,
@@ -9,13 +8,10 @@ import {
   Delete,
   UseGuards,
   ParseIntPipe,
-  HttpCode,
-  HttpStatus,
 } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
-  ApiResponse,
   ApiBearerAuth,
   ApiBody,
   ApiParam,
@@ -52,15 +48,13 @@ export class BecomeSellerController {
   })
   @ApiCreatedResponse({
     description: 'Configuration created successfully',
-    type: BecomeSeller,
+    type: () => BecomeSeller,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @ApiBody({ type: CreateBecomeSellerDto })
-  create(
-    @Body() createBecomeSellerDto: CreateBecomeSellerDto,
-  ): Promise<BecomeSeller> {
+  create(@Body() createBecomeSellerDto: CreateBecomeSellerDto): Promise<BecomeSeller> {
     return this.becomeSellerService.create(createBecomeSellerDto);
   }
 
@@ -72,7 +66,7 @@ export class BecomeSellerController {
   })
   @ApiOkResponse({
     description: 'Configuration retrieved successfully',
-    type: BecomeSeller,
+    type: () => BecomeSeller,
   })
   findAll(): Promise<BecomeSeller> {
     return this.becomeSellerService.findAll();
@@ -82,13 +76,17 @@ export class BecomeSellerController {
   @Public()
   @ApiOperation({
     summary: 'Get become seller configuration by ID',
-    description:
-      'Retrieve a specific become seller configuration by ID (Public)',
+    description: 'Retrieve a specific become seller configuration by ID (Public)',
   })
-  @ApiParam({ name: 'id', description: 'Configuration ID', type: Number })
+  @ApiParam({ 
+    name: 'id', 
+    description: 'Configuration ID', 
+    type: Number,
+    example: 1,
+  })
   @ApiOkResponse({
     description: 'Configuration retrieved successfully',
-    type: BecomeSeller,
+    type: () => BecomeSeller,
   })
   @ApiNotFoundResponse({ description: 'Configuration not found' })
   findOne(@Param('id', ParseIntPipe) id: number): Promise<BecomeSeller> {
@@ -101,10 +99,15 @@ export class BecomeSellerController {
     summary: 'Update become seller configuration',
     description: 'Update become seller configuration by ID (Admin only)',
   })
-  @ApiParam({ name: 'id', description: 'Configuration ID', type: Number })
+  @ApiParam({ 
+    name: 'id', 
+    description: 'Configuration ID', 
+    type: Number,
+    example: 1,
+  })
   @ApiOkResponse({
     description: 'Configuration updated successfully',
-    type: BecomeSeller,
+    type: () => BecomeSeller,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiNotFoundResponse({ description: 'Configuration not found' })
@@ -120,10 +123,14 @@ export class BecomeSellerController {
   @Roles(Permission.SUPER_ADMIN)
   @ApiOperation({
     summary: 'Delete become seller configuration',
-    description:
-      'Permanently delete a become seller configuration by ID (Admin only)',
+    description: 'Soft delete a become seller configuration by ID (Admin only)',
   })
-  @ApiParam({ name: 'id', description: 'Configuration ID', type: Number })
+  @ApiParam({ 
+    name: 'id', 
+    description: 'Configuration ID', 
+    type: Number,
+    example: 1,
+  })
   @ApiOkResponse({
     description: 'Configuration deleted successfully',
     type: CoreMutationOutput,

--- a/api/rest/src/become-seller/become-seller.module.ts
+++ b/api/rest/src/become-seller/become-seller.module.ts
@@ -1,4 +1,3 @@
-// become-seller/become-seller.module.ts
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BecomeSellerController } from './become-seller.controller';

--- a/api/rest/src/become-seller/become-seller.service.ts
+++ b/api/rest/src/become-seller/become-seller.service.ts
@@ -1,4 +1,3 @@
-// become-seller/become-seller.service.ts
 import {
   Injectable,
   NotFoundException,
@@ -6,12 +5,10 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { plainToClass } from 'class-transformer';
 import { BecomeSeller } from './entities/become-seller.entity';
 import { CreateBecomeSellerDto } from './dto/create-become-seller.dto';
 import { UpdateBecomeSellerDto } from './dto/update-become-seller.dto';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
-import becomeSellerJson from '@db/become-seller.json';
 
 @Injectable()
 export class BecomeSellerService {
@@ -20,24 +17,24 @@ export class BecomeSellerService {
     private becomeSellerRepository: Repository<BecomeSeller>,
   ) {}
 
-  async create(
-    createBecomeSellerDto: CreateBecomeSellerDto,
-  ): Promise<BecomeSeller> {
-    // Check if configuration already exists
+  async create(createBecomeSellerDto: CreateBecomeSellerDto): Promise<BecomeSeller> {
     const existing = await this.becomeSellerRepository.findOne({
       where: { language: createBecomeSellerDto.language || 'en' },
     });
 
+    // If a configuration already exists for the requested language,
+    // merge the incoming data into the existing record and save (idempotent).
     if (existing) {
-      throw new ConflictException(
-        'Become seller configuration already exists for this language',
-      );
+      existing.page_options = createBecomeSellerDto.page_options ?? existing.page_options;
+      existing.commissions = createBecomeSellerDto.commissions ?? existing.commissions;
+      existing.language = createBecomeSellerDto.language ?? existing.language;
+
+      return this.becomeSellerRepository.save(existing);
     }
 
-    // Transform DTO to entity format
     const becomeSeller = this.becomeSellerRepository.create({
-      page_options: createBecomeSellerDto.page_options as any,
-      commissions: createBecomeSellerDto.commissions as any,
+      page_options: createBecomeSellerDto.page_options,
+      commissions: createBecomeSellerDto.commissions,
       language: createBecomeSellerDto.language || 'en',
     });
 
@@ -45,30 +42,27 @@ export class BecomeSellerService {
   }
 
   async findAll(): Promise<BecomeSeller> {
-    // Get the default language configuration (usually English)
     const becomeSeller = await this.becomeSellerRepository.findOne({
       where: { language: 'en' },
     });
 
     if (!becomeSeller) {
-      // If no configuration exists, return empty object
       return {
         id: 0,
         page_options: {
-          page_options: {
-            banner: null,
-            sellingStepsTitle: '',
-            sellingStepsDescription: '',
-            sellingStepsItem: [],
-            purposeTitle: '',
-            purposeDescription: '',
-            purposeItems: [],
-            commissionTitle: '',
-            commissionDescription: '',
-            faqTitle: '',
-            faqDescription: '',
-            faqItems: [],
-          },
+          // Provide an empty Attachment-shaped object to satisfy the type
+          banner: ({ thumbnail: '', original: '', file_name: '' } as any),
+          sellingStepsTitle: '',
+          sellingStepsDescription: '',
+          sellingStepsItem: [],
+          purposeTitle: '',
+          purposeDescription: '',
+          purposeItems: [],
+          commissionTitle: '',
+          commissionDescription: '',
+          faqTitle: '',
+          faqDescription: '',
+          faqItems: [],
         },
         commissions: [],
         language: 'en',
@@ -98,15 +92,32 @@ export class BecomeSellerService {
     id: number,
     updateBecomeSellerDto: UpdateBecomeSellerDto,
   ): Promise<BecomeSeller> {
-    const becomeSeller = await this.findOne(id);
+    let becomeSeller: BecomeSeller;
 
-    // Update fields with type assertion to handle the mismatch
+    try {
+      becomeSeller = await this.findOne(id);
+    } catch (err) {
+      // If not found by id, try to locate by language from payload (if provided)
+      if (updateBecomeSellerDto.language) {
+        const found = await this.becomeSellerRepository.findOne({
+          where: { language: updateBecomeSellerDto.language },
+        });
+        if (!found) {
+          // rethrow original not found error
+          throw err;
+        }
+        becomeSeller = found;
+      } else {
+        throw err;
+      }
+    }
+
     if (updateBecomeSellerDto.page_options) {
-      becomeSeller.page_options = updateBecomeSellerDto.page_options as any;
+      becomeSeller.page_options = updateBecomeSellerDto.page_options;
     }
 
     if (updateBecomeSellerDto.commissions) {
-      becomeSeller.commissions = updateBecomeSellerDto.commissions as any;
+      becomeSeller.commissions = updateBecomeSellerDto.commissions;
     }
 
     if (updateBecomeSellerDto.language) {
@@ -119,36 +130,11 @@ export class BecomeSellerService {
   async remove(id: number): Promise<CoreMutationOutput> {
     const becomeSeller = await this.findOne(id);
 
-    await this.becomeSellerRepository.remove(becomeSeller);
+    await this.becomeSellerRepository.softDelete(id);
 
     return {
       success: true,
       message: `Become seller configuration with ID ${id} deleted successfully`,
     };
-  }
-
-  // Helper method to initialize default data from JSON
-  async initializeDefaultData(): Promise<void> {
-    const count = await this.becomeSellerRepository.count();
-
-    if (count === 0) {
-      try {
-        // Parse JSON data
-        const defaultData = plainToClass(BecomeSeller, becomeSellerJson as any);
-
-        // Create default configuration
-        await this.becomeSellerRepository.save({
-          ...defaultData,
-          language: 'en',
-        });
-
-        console.log('✅ Default become seller configuration initialized');
-      } catch (error) {
-        console.error(
-          '❌ Failed to initialize default become seller data:',
-          error.message,
-        );
-      }
-    }
   }
 }

--- a/api/rest/src/become-seller/dto/become-seller-response.dto.ts
+++ b/api/rest/src/become-seller/dto/become-seller-response.dto.ts
@@ -1,14 +1,13 @@
-// become-seller/dto/become-seller-response.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { BecomeSeller } from '../entities/become-seller.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 
 export class BecomeSellerResponse {
-  @ApiProperty({ type: BecomeSeller })
+  @ApiProperty({ type: () => BecomeSeller, description: 'Become seller configuration data' })
   data: BecomeSeller;
 }
 
 export class BecomeSellerMutationResponse extends CoreMutationOutput {
-  @ApiProperty({ type: BecomeSeller, required: false })
+  @ApiProperty({ type: () => BecomeSeller, required: false, description: 'Updated become seller configuration' })
   data?: BecomeSeller;
 }

--- a/api/rest/src/become-seller/dto/create-become-seller.dto.ts
+++ b/api/rest/src/become-seller/dto/create-become-seller.dto.ts
@@ -1,5 +1,4 @@
-// become-seller/dto/create-become-seller.dto.ts
-import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsString,
   IsOptional,
@@ -9,53 +8,45 @@ import {
   IsObject,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import {
-  BecomeSeller,
-  BecomeSellerOptions,
-  CommissionItem,
-  SellingStepItem,
-  BusinessPurposeItem,
-  FaqItems,
-} from '../entities/become-seller.entity';
 import { Attachment } from '../../common/entities/attachment.entity';
 
 export class AttachmentDto {
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: Number, example: 1, description: 'Attachment ID' })
   @IsNumber()
   @IsOptional()
   id?: number;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, example: 'thumbnail.jpg', description: 'Thumbnail URL' })
   @IsString()
   @IsOptional()
   thumbnail?: string;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, example: 'original.jpg', description: 'Original image URL' })
   @IsString()
   @IsOptional()
   original?: string;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, example: 'file.jpg', description: 'File name' })
   @IsString()
   @IsOptional()
   file_name?: string;
 }
 
 export class SellingStepItemDto {
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, example: 'step-1', description: 'Step ID' })
   @IsString()
   @IsOptional()
   id?: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Create Account', description: 'Step title' })
   @IsString()
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Sign up for free account', description: 'Step description' })
   @IsString()
   description: string;
 
-  @ApiProperty({ type: AttachmentDto, required: false })
+  @ApiProperty({ type: AttachmentDto, required: false, description: 'Step image' })
   @ValidateNested()
   @Type(() => AttachmentDto)
   @IsOptional()
@@ -63,20 +54,24 @@ export class SellingStepItemDto {
 }
 
 export class BusinessPurposeItemDto {
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, example: 'purpose-1', description: 'Purpose ID' })
   @IsString()
   @IsOptional()
   id?: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Start Selling', description: 'Purpose title' })
   @IsString()
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Reach more customers', description: 'Purpose description' })
   @IsString()
   description: string;
 
-  @ApiProperty({ type: Object })
+  @ApiProperty({ 
+    type: Object, 
+    example: { value: 'StoreIcon' },
+    description: 'Icon object with value property',
+  })
   @IsObject()
   icon: {
     value: string;
@@ -84,66 +79,66 @@ export class BusinessPurposeItemDto {
 }
 
 export class FaqItemsDto {
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'How to start?', description: 'FAQ question title' })
   @IsString()
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Follow these steps...', description: 'FAQ answer description' })
   @IsString()
   description: string;
 }
 
 export class BecomeSellerOptionsDto {
-  @ApiProperty({ type: AttachmentDto })
+  @ApiProperty({ type: AttachmentDto, description: 'Banner image' })
   @ValidateNested()
   @Type(() => AttachmentDto)
   banner: AttachmentDto;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Start Selling In 4 Simple Steps', description: 'Selling steps section title' })
   @IsString()
   sellingStepsTitle: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Launching your online business with PickBazar is a breeze.', description: 'Selling steps section description' })
   @IsString()
   sellingStepsDescription: string;
 
-  @ApiProperty({ type: [SellingStepItemDto] })
+  @ApiProperty({ type: [SellingStepItemDto], description: 'Array of selling steps' })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => SellingStepItemDto)
   sellingStepsItem: SellingStepItemDto[];
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Why Sell with PickBazar', description: 'Purpose section title' })
   @IsString()
   purposeTitle: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Embarking on your digital entrepreneurship journey', description: 'Purpose section description' })
   @IsString()
   purposeDescription: string;
 
-  @ApiProperty({ type: [BusinessPurposeItemDto] })
+  @ApiProperty({ type: [BusinessPurposeItemDto], description: 'Array of business purposes' })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => BusinessPurposeItemDto)
   purposeItems: BusinessPurposeItemDto[];
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Fee and Commission', description: 'Commission section title' })
   @IsString()
   commissionTitle: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Starting your online business with PickBazar is easy.', description: 'Commission section description' })
   @IsString()
   commissionDescription: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Frequently Ask Question', description: 'FAQ section title' })
   @IsString()
   faqTitle: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Answers to common questions about our services', description: 'FAQ section description' })
   @IsString()
   faqDescription: string;
 
-  @ApiProperty({ type: [FaqItemsDto] })
+  @ApiProperty({ type: [FaqItemsDto], description: 'Array of FAQ items' })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => FaqItemsDto)
@@ -151,63 +146,84 @@ export class BecomeSellerOptionsDto {
 }
 
 export class CommissionItemDto {
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: Number, example: 1, description: 'Commission ID' })
   @IsNumber()
   @IsOptional()
   id?: number;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Level One', description: 'Commission level name' })
   @IsString()
   level: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Charges for listing a product', description: 'Sub level description' })
   @IsString()
   sub_level: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, example: 'Earn attractive commissions with every sale', description: 'Commission description' })
   @IsString()
   description: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: Number, example: 200, description: 'Minimum balance required' })
   @IsNumber()
   min_balance: number;
 
-  @ApiProperty()
+  @ApiProperty({ type: Number, example: 3000, description: 'Maximum balance limit' })
   @IsNumber()
   max_balance: number;
 
-  @ApiProperty()
+  @ApiProperty({ type: Number, example: 15, description: 'Commission percentage' })
   @IsNumber()
   commission: number;
 
-  @ApiProperty({ type: AttachmentDto })
+  @ApiProperty({ type: AttachmentDto, description: 'Commission image/icon' })
   @ValidateNested()
   @Type(() => AttachmentDto)
   image: AttachmentDto;
 
-  @ApiProperty({ default: 'en' })
+  @ApiProperty({ default: 'en', type: String, example: 'en', description: 'Language code' })
   @IsString()
   @IsOptional()
   language?: string;
 }
 
 export class CreateBecomeSellerDto {
-  @ApiProperty({ type: Object })
+  @ApiProperty({ 
+    type: () => BecomeSellerOptionsDto,
+    description: 'Page options configuration containing all content sections',
+  })
   @IsObject()
   @ValidateNested()
   @Type(() => BecomeSellerOptionsDto)
-  page_options: {
-    page_options: BecomeSellerOptionsDto;
-  };
+  page_options: BecomeSellerOptionsDto;
 
-  @ApiProperty({ type: [CommissionItemDto] })
+  @ApiProperty({ 
+    type: () => [CommissionItemDto],
+    description: 'Array of commission items for different levels',
+    example: [
+      {
+        level: 'Level One',
+        sub_level: 'Charges for listing a product',
+        description: 'Earn attractive commissions with every sale',
+        min_balance: 200,
+        max_balance: 3000,
+        commission: 15,
+        image: { thumbnail: 'image.jpg', original: 'image.jpg' }
+      }
+    ],
+  })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => CommissionItemDto)
   commissions: CommissionItemDto[];
 
-  @ApiProperty({ default: 'en' })
+  @ApiProperty({ 
+    default: 'en', 
+    required: false,
+    type: String,
+    example: 'en',
+    description: 'Language code for the configuration',
+  })
   @IsString()
   @IsOptional()
-  language?: string;
+  language?: string = 'en';
 }

--- a/api/rest/src/become-seller/dto/update-become-seller.dto.ts
+++ b/api/rest/src/become-seller/dto/update-become-seller.dto.ts
@@ -1,4 +1,3 @@
-// become-seller/dto/update-become-seller.dto.ts
 import { PartialType } from '@nestjs/swagger';
 import { CreateBecomeSellerDto } from './create-become-seller.dto';
 

--- a/api/rest/src/become-seller/entities/become-seller.entity.ts
+++ b/api/rest/src/become-seller/entities/become-seller.entity.ts
@@ -1,171 +1,184 @@
-// become-seller/entities/become-seller.entity.ts
 import {
   Entity,
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { CoreEntity } from '../../common/entities/core.entity';
 
 export class Attachment {
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: Number, description: 'Attachment ID', example: 1 })
   id?: number;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, description: 'Thumbnail URL', example: 'https://example.com/thumbnail.jpg' })
   thumbnail?: string;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, description: 'Original image URL', example: 'https://example.com/image.jpg' })
   original?: string;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, description: 'File name', example: 'image.jpg' })
   file_name?: string;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: Date, description: 'Creation timestamp' })
   created_at?: Date;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: Date, description: 'Last update timestamp' })
   updated_at?: Date;
 }
 
 export class SellingStepItem {
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, description: 'Step ID', example: 'step-1' })
   id?: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Step title', example: 'Create Account' })
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Step description', example: 'Sign up for free account' })
   description: string;
 
-  @ApiProperty({ type: Attachment, required: false })
+  @ApiProperty({ type: Attachment, required: false, description: 'Step image' })
   @Type(() => Attachment)
   image?: Attachment;
 }
 
 export class BusinessPurposeItem {
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, type: String, description: 'Purpose ID', example: 'purpose-1' })
   id?: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Purpose title', example: 'Start Selling' })
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Purpose description', example: 'Reach more customers' })
   description: string;
 
-  @ApiProperty({ type: Object })
+  @ApiProperty({ type: Object, description: 'Icon object with value property', example: { value: 'StoreIcon' } })
   icon: {
     value: string;
   };
 }
 
 export class FaqItems {
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'FAQ question title', example: 'How to start?' })
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'FAQ answer description', example: 'Follow these steps...' })
   description: string;
 }
 
 export class BecomeSellerOptions {
-  @ApiProperty({ type: Attachment })
+  @ApiProperty({ type: Attachment, description: 'Banner image' })
   @Type(() => Attachment)
   banner: Attachment;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Selling steps section title', example: 'Start Selling In 4 Simple Steps' })
   sellingStepsTitle: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Selling steps section description', example: 'Launching your online business with PickBazar is a breeze.' })
   sellingStepsDescription: string;
 
-  @ApiProperty({ type: [SellingStepItem] })
+  @ApiProperty({ type: [SellingStepItem], description: 'Array of selling steps' })
   @Type(() => SellingStepItem)
   sellingStepsItem: SellingStepItem[];
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Purpose section title', example: 'Why Sell with PickBazar' })
   purposeTitle: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Purpose section description', example: 'Embarking on your digital entrepreneurship journey' })
   purposeDescription: string;
 
-  @ApiProperty({ type: [BusinessPurposeItem] })
+  @ApiProperty({ type: [BusinessPurposeItem], description: 'Array of business purposes' })
   @Type(() => BusinessPurposeItem)
   purposeItems: BusinessPurposeItem[];
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Commission section title', example: 'Fee and Commission' })
   commissionTitle: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Commission section description', example: 'Starting your online business with PickBazar is easy.' })
   commissionDescription: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'FAQ section title', example: 'Frequently Ask Question' })
   faqTitle: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'FAQ section description', example: 'Answers to common questions about our services' })
   faqDescription: string;
 
-  @ApiProperty({ type: [FaqItems] })
+  @ApiProperty({ type: [FaqItems], description: 'Array of FAQ items' })
   @Type(() => FaqItems)
   faqItems: FaqItems[];
 }
 
 export class CommissionItem {
-  @ApiProperty()
+  @ApiProperty({ type: Number, description: 'Commission ID', example: 1 })
   id?: number;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Commission level name', example: 'Level One' })
   level: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Sub level description', example: 'Charges for listing a product' })
   sub_level: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Commission description', example: 'Earn attractive commissions with every sale' })
   description: string;
 
-  @ApiProperty()
+  @ApiProperty({ type: Number, description: 'Minimum balance required', example: 200 })
   min_balance: number;
 
-  @ApiProperty()
+  @ApiProperty({ type: Number, description: 'Maximum balance limit', example: 3000 })
   max_balance: number;
 
-  @ApiProperty()
+  @ApiProperty({ type: Number, description: 'Commission percentage', example: 15 })
   commission: number;
 
-  @ApiProperty({ type: Attachment })
+  @ApiProperty({ type: Attachment, description: 'Commission image/icon' })
   @Type(() => Attachment)
   image: Attachment;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, description: 'Language code', example: 'en', default: 'en' })
   language?: string;
 }
 
 @Entity('become_seller')
 export class BecomeSeller extends CoreEntity {
-  @ApiProperty({ description: 'Become Seller ID' })
+  @ApiProperty({ description: 'Become Seller ID', type: Number, example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ApiProperty({ type: Object })
+  @ApiProperty({ 
+    type: () => BecomeSellerOptions,
+    description: 'Page options configuration containing all content sections',
+  })
   @Column('json')
-  page_options: {
-    page_options: BecomeSellerOptions;
-  };
+  page_options: BecomeSellerOptions;
 
-  @ApiProperty({ type: [CommissionItem] })
+  @ApiProperty({ 
+    type: () => [CommissionItem],
+    description: 'Array of commission items for different levels',
+  })
   @Column('json')
   commissions: CommissionItem[];
 
-  @ApiProperty({ description: 'Language code', default: 'en' })
+  @ApiProperty({ 
+    description: 'Language code', 
+    default: 'en',
+    type: String,
+    example: 'en',
+  })
   @Column({ default: 'en' })
   language: string;
 
-  @ApiProperty({ description: 'Creation timestamp' })
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
+
+  @ApiProperty({ description: 'Creation timestamp', type: Date })
   @CreateDateColumn()
   created_at: Date;
 
-  @ApiProperty({ description: 'Last update timestamp' })
+  @ApiProperty({ description: 'Last update timestamp', type: Date })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/api/rest/src/common/enums/become-seller.enum.ts
+++ b/api/rest/src/common/enums/become-seller.enum.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum BecomeSellerOrderByColumn {
+  CREATED_AT = 'created_at',
+  UPDATED_AT = 'updated_at',
+  LANGUAGE = 'language',
+}


### PR DESCRIPTION
Make become-seller features more robust and improve API docs/validation, plus fix JWT extraction.

Key changes:
- auth: replace default ExtractJwt.fromAuthHeaderAsBearerToken with a robust extractor that strips duplicate/quoted "Bearer" occurrences.
- become-seller controller: tighten Swagger decorators (use lazy type functions, add @ApiParam examples/descriptions), simplify method signatures and adjust delete description to soft delete.
- DTOs: enrich Create/response DTOs with detailed ApiProperty metadata, examples, validation decorators and sensible defaults (language defaults to 'en'); restructure nested DTOs (AttachmentDto, SellingStepItemDto, etc.).
- Service: make create idempotent by merging into existing language entry instead of throwing Conflict; update handles fallback by language; findAll returns a well-formed default object when none exists; replace hard remove with softDelete; remove unused default-initialization logic and unused imports.
- Entities: add DeleteDateColumn (deleted_at) for soft deletes, improve ApiProperty metadata across models, and adjust json column shapes to use typed option classes.
- Add BecomeSellerOrderByColumn enum for ordering constants.

Also minor cleanup: removed file header comments and several unused imports, and corrected types in multiple places to improve consistency.