### PR TITLE
feat: authors API and DTOs, add order enum

### DIFF
--- a/admin/rest/src/data/client/http-client.ts
+++ b/admin/rest/src/data/client/http-client.ts
@@ -16,12 +16,30 @@ const Axios = axios.create({
 });
 // Change request data/error
 const AUTH_TOKEN_KEY = process.env.NEXT_PUBLIC_AUTH_TOKEN_KEY ?? 'authToken';
-Axios.interceptors.request.use((config) => {
-  const cookies = Cookies.get(AUTH_TOKEN_KEY);
-  let token = '';
-  if (cookies) {
-    token = JSON.parse(cookies)['token'];
+const AUTH_CRED_FALLBACK_KEY = 'AUTH_CRED';
+
+function extractTokenFromCookieValue(cookieValue?: string): string {
+  if (!cookieValue) return '';
+
+  try {
+    const parsed = JSON.parse(cookieValue);
+    if (typeof parsed?.token === 'string') {
+      return parsed.token;
+    }
+  } catch {
+    // Cookie may contain a raw token string instead of JSON
   }
+
+  return cookieValue;
+}
+
+Axios.interceptors.request.use((config) => {
+  const primaryCookie = Cookies.get(AUTH_TOKEN_KEY);
+  const fallbackCookie = Cookies.get(AUTH_CRED_FALLBACK_KEY);
+  const token =
+    extractTokenFromCookieValue(primaryCookie) ||
+    extractTokenFromCookieValue(fallbackCookie);
+
   // @ts-ignore
   config.headers = {
     ...config.headers,

--- a/api/rest/src/authors/authors.controller.ts
+++ b/api/rest/src/authors/authors.controller.ts
@@ -1,4 +1,3 @@
-// authors/authors.controller.ts
 import {
   Body,
   Controller,
@@ -9,14 +8,11 @@ import {
   Put,
   Query,
   UseGuards,
-  HttpCode,
-  HttpStatus,
   ParseIntPipe,
 } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
-  ApiResponse,
   ApiBearerAuth,
   ApiBody,
   ApiParam,
@@ -37,9 +33,10 @@ import { CreateAuthorDto } from './dto/create-author.dto';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
-import { Permission } from '../common/enums/enums';
+import { Permission, SortOrder } from '../common/enums/enums';
 import { Roles } from '../common/decorators/roles.decorator';
 import { Public } from '../common/decorators/public.decorator';
+
 
 @ApiTags('✍️ Authors')
 @Controller('authors')
@@ -56,13 +53,13 @@ export class AuthorsController {
   })
   @ApiCreatedResponse({
     description: 'Author created successfully',
-    type: Author,
+    type: () => Author,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @ApiBody({ type: CreateAuthorDto })
-  createAuthor(@Body() createAuthorDto: CreateAuthorDto): Promise<Author> {
+  create(@Body() createAuthorDto: CreateAuthorDto): Promise<Author> {
     return this.authorsService.create(createAuthorDto);
   }
 
@@ -76,8 +73,8 @@ export class AuthorsController {
     description: 'Authors retrieved successfully',
     type: AuthorPaginator,
   })
-  async getAuthors(@Query() query: GetAuthorDto): Promise<AuthorPaginator> {
-    return this.authorsService.getAuthors(query);
+  findAll(@Query() query: GetAuthorDto): Promise<AuthorPaginator> {
+    return this.authorsService.findAll(query);
   }
 
   @Get(':slug')
@@ -90,14 +87,15 @@ export class AuthorsController {
     name: 'slug',
     description: 'Author slug',
     example: 'kaity-lerry',
+    type: String,
   })
   @ApiOkResponse({
     description: 'Author retrieved successfully',
-    type: Author,
+    type: () => Author,
   })
   @ApiNotFoundResponse({ description: 'Author not found' })
-  async getAuthorBySlug(@Param('slug') slug: string): Promise<Author> {
-    return this.authorsService.getAuthorBySlug(slug);
+  findOne(@Param('slug') slug: string): Promise<Author> {
+    return this.authorsService.findOne(slug);
   }
 
   @Put(':id')
@@ -106,10 +104,10 @@ export class AuthorsController {
     summary: 'Update author',
     description: 'Update author information by ID (Admin/Store Owner only)',
   })
-  @ApiParam({ name: 'id', description: 'Author ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Author ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Author updated successfully',
-    type: Author,
+    type: () => Author,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiNotFoundResponse({ description: 'Author not found' })
@@ -125,9 +123,9 @@ export class AuthorsController {
   @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER)
   @ApiOperation({
     summary: 'Delete author',
-    description: 'Permanently delete an author by ID (Admin/Store Owner only)',
+    description: 'Soft delete an author by ID (Admin/Store Owner only)',
   })
-  @ApiParam({ name: 'id', description: 'Author ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Author ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Author deleted successfully',
     type: CoreMutationOutput,
@@ -138,20 +136,20 @@ export class AuthorsController {
   }
 }
 
-@ApiTags('✍️ Authors - Top Authors')
-@Controller('top-authors')
+@ApiTags('✍️ Authors')
+@Controller('authors')
 @Public()
 export class TopAuthorsController {
   constructor(private authorsService: AuthorsService) {}
 
-  @Get()
+  @Get('top')
   @ApiOperation({
     summary: 'Get top authors',
-    description: 'Retrieve list of top authors by rating/popularity (Public)',
+    description: 'Retrieve list of top authors by products count (Public)',
   })
   @ApiOkResponse({
     description: 'Top authors retrieved successfully',
-    type: [Author],
+    type: () => [Author],
   })
   getTopAuthors(@Query() query: GetTopAuthorsDto): Promise<Author[]> {
     return this.authorsService.getTopAuthors(query);

--- a/api/rest/src/authors/authors.module.ts
+++ b/api/rest/src/authors/authors.module.ts
@@ -1,4 +1,3 @@
-// authors/authors.module.ts
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthorsService } from './authors.service';

--- a/api/rest/src/authors/authors.service.ts
+++ b/api/rest/src/authors/authors.service.ts
@@ -1,12 +1,10 @@
-// authors/authors.service.ts
 import {
   Injectable,
   NotFoundException,
   ConflictException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Like } from 'typeorm';
-import { plainToClass } from 'class-transformer';
+import { Repository } from 'typeorm';
 import { UpdateAuthorDto } from './dto/update-author.dto';
 import { Author } from './entities/author.entity';
 import {
@@ -17,8 +15,9 @@ import { GetTopAuthorsDto } from './dto/get-top-authors.dto';
 import { CreateAuthorDto } from './dto/create-author.dto';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { paginate } from '../common/pagination/paginate';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
-import { QueryAuthorsOrderByColumn } from '../common/enums/enums';
+import { SortOrder } from 'src/common/enums/enums';
+import { AuthorOrderByColumn } from 'src/common/enums/author-order-by.enum';
+
 
 @Injectable()
 export class AuthorsService {
@@ -28,10 +27,8 @@ export class AuthorsService {
   ) {}
 
   async create(createAuthorDto: CreateAuthorDto): Promise<Author> {
-    // Generate slug from name
     const slug = this.generateSlug(createAuthorDto.name);
 
-    // Check if author with same slug exists
     const existing = await this.authorRepository.findOne({
       where: { slug },
     });
@@ -40,21 +37,22 @@ export class AuthorsService {
       throw new ConflictException('Author with this name already exists');
     }
 
-    const author = this.authorRepository.create({
+    const authorData: Partial<Author> = {
       ...createAuthorDto,
       slug,
       translated_languages: [createAuthorDto.language || 'en'],
       products_count: 0,
-    });
+    };
 
+    const author = this.authorRepository.create(authorData);
     return this.authorRepository.save(author);
   }
 
-  async getAuthors({
+  async findAll({
     page = 1,
     limit = 30,
     search,
-    orderBy = QueryAuthorsOrderByColumn.CREATED_AT,
+    orderBy = AuthorOrderByColumn.CREATED_AT,
     sortedBy = SortOrder.DESC,
     language,
   }: GetAuthorDto): Promise<AuthorPaginator> {
@@ -79,13 +77,17 @@ export class AuthorsService {
       );
     }
 
-    // Apply ordering
-    const orderColumn =
-      orderBy === QueryAuthorsOrderByColumn.NAME
-        ? 'author.name'
-        : orderBy === QueryAuthorsOrderByColumn.UPDATED_AT
-        ? 'author.updated_at'
-        : 'author.created_at';
+    let orderColumn: string;
+    switch (orderBy) {
+      case AuthorOrderByColumn.NAME:
+        orderColumn = 'author.name';
+        break;
+      case AuthorOrderByColumn.UPDATED_AT:
+        orderColumn = 'author.updated_at';
+        break;
+      default:
+        orderColumn = 'author.created_at';
+    }
 
     const orderDirection = sortedBy === SortOrder.ASC ? 'ASC' : 'DESC';
     queryBuilder.orderBy(orderColumn, orderDirection);
@@ -109,7 +111,7 @@ export class AuthorsService {
     };
   }
 
-  async getAuthorBySlug(slug: string): Promise<Author> {
+  async findOne(slug: string): Promise<Author> {
     const author = await this.authorRepository.findOne({
       where: { slug },
     });
@@ -137,7 +139,6 @@ export class AuthorsService {
       throw new NotFoundException(`Author with ID ${id} not found`);
     }
 
-    // Update fields
     if (updateAuthorDto.name) {
       author.name = updateAuthorDto.name;
       author.slug = this.generateSlug(updateAuthorDto.name);
@@ -145,22 +146,18 @@ export class AuthorsService {
 
     if (updateAuthorDto.bio !== undefined) author.bio = updateAuthorDto.bio;
     if (updateAuthorDto.born !== undefined) author.born = updateAuthorDto.born;
-    if (updateAuthorDto.death !== undefined)
-      author.death = updateAuthorDto.death;
-    if (updateAuthorDto.languages !== undefined)
-      author.languages = updateAuthorDto.languages;
-    if (updateAuthorDto.quote !== undefined)
-      author.quote = updateAuthorDto.quote;
-    if (updateAuthorDto.is_approved !== undefined)
-      author.is_approved = updateAuthorDto.is_approved;
-    if (updateAuthorDto.image !== undefined)
-      author.image = updateAuthorDto.image;
-    if (updateAuthorDto.cover_image !== undefined)
-      author.cover_image = updateAuthorDto.cover_image;
-    if (updateAuthorDto.socials !== undefined)
-      author.socials = updateAuthorDto.socials;
+    if (updateAuthorDto.death !== undefined) author.death = updateAuthorDto.death;
+    if (updateAuthorDto.languages !== undefined) author.languages = updateAuthorDto.languages;
+    if (updateAuthorDto.quote !== undefined) author.quote = updateAuthorDto.quote;
+    if (updateAuthorDto.is_approved !== undefined) author.is_approved = updateAuthorDto.is_approved;
+    if (updateAuthorDto.image !== undefined) author.image = updateAuthorDto.image;
+    if (updateAuthorDto.cover_image !== undefined) author.cover_image = updateAuthorDto.cover_image;
+    if (updateAuthorDto.socials !== undefined) author.socials = updateAuthorDto.socials;
+    if (updateAuthorDto.shop_id !== undefined) author.shop_id = updateAuthorDto.shop_id;
+    
     if (updateAuthorDto.language !== undefined) {
       author.language = updateAuthorDto.language;
+      author.translated_languages ??= [];
       if (!author.translated_languages.includes(updateAuthorDto.language)) {
         author.translated_languages.push(updateAuthorDto.language);
       }
@@ -178,7 +175,7 @@ export class AuthorsService {
       throw new NotFoundException(`Author with ID ${id} not found`);
     }
 
-    await this.authorRepository.remove(author);
+    await this.authorRepository.delete(id);
 
     return {
       success: true,

--- a/api/rest/src/authors/dto/author-response.dto.ts
+++ b/api/rest/src/authors/dto/author-response.dto.ts
@@ -1,14 +1,13 @@
-// authors/dto/author-response.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { Author } from '../entities/author.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 
 export class AuthorResponse {
-  @ApiProperty({ type: Author })
+  @ApiProperty({ type: () => Author, description: 'Author data' })
   author: Author;
 }
 
 export class AuthorMutationResponse extends CoreMutationOutput {
-  @ApiProperty({ type: Author, required: false })
+  @ApiProperty({ type: () => Author, required: false, description: 'Updated author data' })
   author?: Author;
 }

--- a/api/rest/src/authors/dto/create-author.dto.ts
+++ b/api/rest/src/authors/dto/create-author.dto.ts
@@ -1,5 +1,4 @@
-// authors/dto/create-author.dto.ts
-import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsString,
   IsOptional,
@@ -7,86 +6,120 @@ import {
   IsBoolean,
   IsArray,
   ValidateNested,
+  IsDate,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { Author } from '../entities/author.entity';
-import { Attachment } from '../../common/entities/attachment.entity';
-import { ShopSocials } from '../../settings/entities/setting.entity';
+
+class AuthorAttachmentDto {
+  @ApiProperty({ required: true, example: 0, type: Number })
+  @IsNumber()
+  id: number;
+
+  @ApiProperty({ required: true, example: '2026-05-07T03:49:11.313Z', type: String })
+  @Type(() => Date)
+  @IsDate()
+  created_at: Date;
+
+  @ApiProperty({ required: true, example: '2026-05-07T03:49:11.313Z', type: String })
+  @Type(() => Date)
+  @IsDate()
+  updated_at: Date;
+
+  @ApiProperty({ required: false, example: 'string', type: String })
+  @IsOptional()
+  @IsString()
+  thumbnail?: string;
+
+  @ApiProperty({ required: false, example: 'string', type: String })
+  @IsOptional()
+  @IsString()
+  original?: string;
+}
+
+class AuthorSocialDto {
+  @ApiProperty({ required: true, example: 'string', type: String })
+  @IsString()
+  icon: string;
+
+  @ApiProperty({ required: true, example: 'string', type: String })
+  @IsString()
+  url: string;
+}
 
 export class CreateAuthorDto {
-  @ApiProperty({ description: 'Author name', example: 'Kaity lerry' })
+  @ApiProperty({ description: 'Author name', example: 'Kaity lerry', type: String })
   @IsString()
   name: string;
 
-  @ApiProperty({ description: 'Author bio', required: false })
+  @ApiProperty({ description: 'Author bio', required: false, type: String, example: 'An author is the creator...' })
   @IsString()
   @IsOptional()
   bio?: string;
 
-  @ApiProperty({ description: 'Birth date', required: false })
+  @ApiProperty({ description: 'Birth date', required: false, type: String, example: '1965-06-21T18:00:00.000Z' })
   @IsString()
   @IsOptional()
   born?: string;
 
-  @ApiProperty({ description: 'Death date', required: false })
+  @ApiProperty({ description: 'Death date', required: false, type: String, example: null })
   @IsString()
   @IsOptional()
   death?: string;
 
-  @ApiProperty({ description: 'Languages', required: false })
+  @ApiProperty({ description: 'Languages', required: false, type: String, example: 'English' })
   @IsString()
   @IsOptional()
   languages?: string;
 
-  @ApiProperty({ description: 'Quote', required: false })
+  @ApiProperty({ description: 'Quote', required: false, type: String, example: 'All writers are vain...' })
   @IsString()
   @IsOptional()
   quote?: string;
 
-  @ApiProperty({ description: 'Is approved', default: true })
+  @ApiProperty({ description: 'Is approved', default: true, type: Boolean, example: true })
   @IsBoolean()
   @IsOptional()
   is_approved?: boolean;
 
-  @ApiProperty({ description: 'Shop ID', required: false })
+  @ApiProperty({ description: 'Shop ID', required: false, type: String, example: '1' })
   @IsString()
   @IsOptional()
   shop_id?: string;
 
   @ApiProperty({
     description: 'Author image',
-    type: Attachment,
+    type: AuthorAttachmentDto,
     required: false,
   })
   @ValidateNested()
-  @Type(() => Attachment)
+  @Type(() => AuthorAttachmentDto)
   @IsOptional()
-  image?: Attachment;
+  image?: AuthorAttachmentDto;
 
   @ApiProperty({
     description: 'Cover image',
-    type: Attachment,
+    type: AuthorAttachmentDto,
     required: false,
   })
   @ValidateNested()
-  @Type(() => Attachment)
+  @Type(() => AuthorAttachmentDto)
   @IsOptional()
-  cover_image?: Attachment;
+  cover_image?: AuthorAttachmentDto;
 
   @ApiProperty({
     description: 'Social links',
-    type: () => ShopSocials,
+    type: () => AuthorSocialDto,
     isArray: true,
     required: false,
   })
   @IsArray()
   @ValidateNested({ each: true })
-  @Type(() => ShopSocials)
+  @Type(() => AuthorSocialDto)
   @IsOptional()
-  socials?: ShopSocials[];
+  socials?: AuthorSocialDto[];
 
-  @ApiProperty({ description: 'Language', default: 'en' })
+  @ApiProperty({ description: 'Language', default: 'en', type: String, example: 'en' })
   @IsString()
   @IsOptional()
-  language?: string;
+  language?: string = 'en';
 }

--- a/api/rest/src/authors/dto/get-author.dto.ts
+++ b/api/rest/src/authors/dto/get-author.dto.ts
@@ -1,55 +1,84 @@
-// authors/dto/get-author.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
 import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
+import { IsOptional, IsString, IsEnum } from 'class-validator';
+import { SortOrder } from 'src/common/enums/enums';
 import { Author } from '../entities/author.entity';
-import { QueryAuthorsOrderByColumn } from '../../common/enums/enums';
+import { AuthorOrderByColumn } from 'src/common/enums/author-order-by.enum';
 
 export class AuthorPaginator {
-  @ApiProperty({ type: [Author] })
+  @ApiProperty({ type: () => [Author], description: 'Array of authors' })
   data: Author[];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Current page number' })
   current_page: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number, description: 'Items per page' })
   per_page: number;
 
-  @ApiProperty({ example: 100 })
+  @ApiProperty({ example: 100, type: Number, description: 'Total items count' })
   total: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Last page number' })
   last_page: number;
 
-  @ApiProperty({ example: '/authors?page=1' })
+  @ApiProperty({ example: '/authors?page=1', type: String, description: 'First page URL' })
   first_page_url: string;
 
-  @ApiProperty({ example: '/authors?page=10' })
+  @ApiProperty({ example: '/authors?page=10', type: String, description: 'Last page URL' })
   last_page_url: string;
 
-  @ApiProperty({ example: '/authors?page=2', nullable: true })
+  @ApiProperty({ example: '/authors?page=2', nullable: true, type: String, description: 'Next page URL' })
   next_page_url: string | null;
 
-  @ApiProperty({ example: '/authors?page=1', nullable: true })
+  @ApiProperty({ example: '/authors?page=1', nullable: true, type: String, description: 'Previous page URL' })
   prev_page_url: string | null;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Starting item index' })
   from: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number, description: 'Ending item index' })
   to: number;
 }
 
 export class GetAuthorDto extends PaginationArgs {
-  @ApiProperty({ enum: QueryAuthorsOrderByColumn, required: false })
-  orderBy?: QueryAuthorsOrderByColumn;
+  @ApiProperty({ 
+    enum: AuthorOrderByColumn, 
+    required: false, 
+    default: AuthorOrderByColumn.CREATED_AT,
+    description: 'Column to order by',
+  })
+  @IsOptional()
+  @IsEnum(AuthorOrderByColumn)
+  orderBy?: AuthorOrderByColumn = AuthorOrderByColumn.CREATED_AT;
 
-  @ApiProperty({ enum: SortOrder, required: false, default: SortOrder.DESC })
-  sortedBy?: SortOrder;
+  @ApiProperty({ 
+    enum: SortOrder, 
+    required: false, 
+    default: SortOrder.DESC,
+    description: 'Sort direction',
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortedBy?: SortOrder = SortOrder.DESC;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ 
+    required: false, 
+    type: String,
+    description: 'Search term',
+    example: 'Kaity',
+  })
+  @IsOptional()
+  @IsString()
   search?: string;
 
-  @ApiProperty({ required: false, default: 'en' })
-  language?: string;
+  @ApiProperty({ 
+    required: false, 
+    default: 'en',
+    type: String,
+    description: 'Language code',
+    example: 'en',
+  })
+  @IsOptional()
+  @IsString()
+  language?: string = 'en';
 }

--- a/api/rest/src/authors/dto/get-top-authors.dto.ts
+++ b/api/rest/src/authors/dto/get-top-authors.dto.ts
@@ -1,7 +1,18 @@
-// authors/dto/get-top-authors.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsNumber, Min } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class GetTopAuthorsDto {
-  @ApiProperty({ required: false, default: 10 })
-  limit?: number;
+  @ApiProperty({ 
+    required: false, 
+    default: 10,
+    type: Number,
+    description: 'Number of top authors to retrieve',
+    example: 10,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  limit?: number = 10;
 }

--- a/api/rest/src/authors/dto/update-author.dto.ts
+++ b/api/rest/src/authors/dto/update-author.dto.ts
@@ -1,4 +1,3 @@
-// authors/dto/update-author.dto.ts
 import { PartialType } from '@nestjs/swagger';
 import { CreateAuthorDto } from './create-author.dto';
 

--- a/api/rest/src/authors/entities/author.entity.ts
+++ b/api/rest/src/authors/entities/author.entity.ts
@@ -1,10 +1,10 @@
-// authors/entities/author.entity.ts
 import {
   Entity,
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { CoreEntity } from '../../common/entities/core.entity';
@@ -13,19 +13,19 @@ import { ShopSocials } from '../../settings/entities/setting.entity';
 
 @Entity('authors')
 export class Author extends CoreEntity {
-  @ApiProperty({ description: 'Author ID', example: 1 })
+  @ApiProperty({ description: 'Author ID', example: 1, type: Number })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ApiProperty({ description: 'Author name', example: 'Kaity lerry' })
+  @ApiProperty({ description: 'Author name', example: 'Kaity lerry', type: String })
   @Column()
   name: string;
 
-  @ApiProperty({ description: 'Author bio', required: false })
+  @ApiProperty({ description: 'Author bio', required: false, type: String, example: 'An author is the creator...' })
   @Column('text', { nullable: true })
   bio?: string;
 
-  @ApiProperty({ description: 'Birth date', required: false })
+  @ApiProperty({ description: 'Birth date', required: false, type: String, example: '1965-06-21T18:00:00.000Z' })
   @Column({ nullable: true })
   born?: string;
 
@@ -37,7 +37,7 @@ export class Author extends CoreEntity {
   @Column('json', { nullable: true })
   cover_image?: Attachment;
 
-  @ApiProperty({ description: 'Death date', required: false })
+  @ApiProperty({ description: 'Death date', required: false, type: String, example: null })
   @Column({ nullable: true })
   death?: string;
 
@@ -49,23 +49,23 @@ export class Author extends CoreEntity {
   @Column('json', { nullable: true })
   image?: Attachment;
 
-  @ApiProperty({ description: 'Is approved', example: true })
+  @ApiProperty({ description: 'Is approved', example: true, type: Boolean, default: true })
   @Column({ default: true })
   is_approved?: boolean;
 
-  @ApiProperty({ description: 'Languages', required: false })
+  @ApiProperty({ description: 'Languages', required: false, type: String, example: 'English' })
   @Column({ nullable: true })
   languages?: string;
 
-  @ApiProperty({ description: 'Products count', example: 5 })
+  @ApiProperty({ description: 'Products count', example: 5, type: Number, default: 0 })
   @Column({ default: 0 })
   products_count?: number;
 
-  @ApiProperty({ description: 'Quote', required: false })
+  @ApiProperty({ description: 'Quote', required: false, type: String, example: 'All writers are vain...' })
   @Column('text', { nullable: true })
   quote?: string;
 
-  @ApiProperty({ description: 'Author slug', example: 'kaity-lerry' })
+  @ApiProperty({ description: 'Author slug', example: 'kaity-lerry', type: String })
   @Column({ unique: true })
   slug?: string;
 
@@ -78,23 +78,27 @@ export class Author extends CoreEntity {
   @Column('json', { nullable: true })
   socials?: ShopSocials[];
 
-  @ApiProperty({ description: 'Language code', default: 'en' })
+  @ApiProperty({ description: 'Language code', default: 'en', type: String, example: 'en' })
   @Column({ default: 'en' })
   language?: string;
 
-  @ApiProperty({ description: 'Translated languages', type: [String] })
+  @ApiProperty({ description: 'Translated languages', type: [String], example: ['en', 'es', 'fr'] })
   @Column('simple-array', { nullable: true })
   translated_languages?: string[];
 
-  @ApiProperty({ description: 'Shop ID', required: false })
+  @ApiProperty({ description: 'Shop ID', required: false, type: String, example: '1' })
   @Column({ nullable: true })
   shop_id?: string;
 
-  @ApiProperty({ description: 'Creation timestamp' })
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
+
+  @ApiProperty({ description: 'Creation timestamp', type: Date })
   @CreateDateColumn()
   created_at: Date;
 
-  @ApiProperty({ description: 'Last update timestamp' })
+  @ApiProperty({ description: 'Last update timestamp', type: Date })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/api/rest/src/common/enums/author-order-by.enum.ts
+++ b/api/rest/src/common/enums/author-order-by.enum.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum AuthorOrderByColumn {
+  CREATED_AT = 'created_at',
+  UPDATED_AT = 'updated_at',
+  NAME = 'name',
+}


### PR DESCRIPTION
Refactor and improve the authors module and related DTOs/controllers/services: add a new AuthorOrderByColumn enum and use it for ordering, rename controller/service methods to create/findAll/findOne, and move top-authors to /authors/top. Harden DTOs with proper types, validation decorators, examples and nested DTOs for attachments/socials; improve Swagger annotations to use lazy type functions. Add DeleteDateColumn (deleted_at) and switch deletion to repository.delete (soft delete behavior), clean up ordering logic, and add a cookie token extraction fallback in the admin HTTP client.