### PR TITLE
fix: Use type_id for categories; add image util

### DIFF
--- a/admin/rest/src/components/category/category-list.tsx
+++ b/admin/rest/src/components/category/category-list.tsx
@@ -13,6 +13,7 @@ import { Routes } from '@/config/routes';
 import LanguageSwitcher from '@/components/ui/lang-action/action';
 import { NoDataFound } from '@/components/icons/no-data-found';
 import { siteSettings } from '@/settings/site.settings';
+import { getValidImageSrc } from '@/utils/get-valid-image-src';
 
 export type IProps = {
   categories: Category[] | undefined;
@@ -84,7 +85,10 @@ const CategoryList = ({
           <div className="flex items-center">
             <div className="relative aspect-square h-10 w-10 shrink-0 overflow-hidden rounded border border-border-200/80 bg-gray-100 me-2.5">
               <Image
-                src={image?.thumbnail ?? siteSettings.product.placeholder}
+                src={getValidImageSrc(
+                  image?.thumbnail,
+                  siteSettings.product.placeholder
+                )}
                 alt={name}
                 fill
                 priority={true}
@@ -142,16 +146,13 @@ const CategoryList = ({
     },
     {
       title: t('table:table-item-group'),
-      dataIndex: 'type',
-      key: 'type',
+      dataIndex: 'type_id',
+      key: 'type_id',
       align: 'center',
       width: 120,
-      render: (type: any) => (
-        <div
-          className="overflow-hidden truncate whitespace-nowrap"
-          title={type?.name}
-        >
-          {type?.name}
+      render: (type_id: any) => (
+        <div className="overflow-hidden truncate whitespace-nowrap">
+          {type_id || '-'}
         </div>
       ),
     },

--- a/admin/rest/src/data/client/http-client.ts
+++ b/admin/rest/src/data/client/http-client.ts
@@ -40,11 +40,13 @@ Axios.interceptors.request.use((config) => {
     extractTokenFromCookieValue(primaryCookie) ||
     extractTokenFromCookieValue(fallbackCookie);
 
-  // @ts-ignore
-  config.headers = {
-    ...config.headers,
-    Authorization: `Bearer ${token}`,
-  };
+  if (token) {
+    // @ts-ignore
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${token}`,
+    };
+  }
   return config;
 });
 

--- a/admin/rest/src/utils/get-valid-image-src.ts
+++ b/admin/rest/src/utils/get-valid-image-src.ts
@@ -1,0 +1,21 @@
+export function getValidImageSrc(src: unknown, fallback: string): string {
+  if (typeof src !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = src.trim();
+
+  if (!trimmed || trimmed === 'string' || trimmed === '[object Object]') {
+    return fallback;
+  }
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  return `/${trimmed}`;
+}

--- a/api/rest/src/categories/categories.service.ts
+++ b/api/rest/src/categories/categories.service.ts
@@ -70,8 +70,6 @@ export class CategoriesService {
       .createQueryBuilder('category')
       .leftJoinAndSelect('category.parent', 'parent');
 
-    queryBuilder.leftJoinAndSelect('category.type', 'type');
-
     if (search) {
       const searchTokens = search
         .split(';')
@@ -180,8 +178,9 @@ export class CategoriesService {
     }
 
     if (key === 'type.slug' || key === 'type') {
+      // Type is now a simple foreign key reference, filter by type_id
       return {
-        clause: 'type.slug = :value',
+        clause: 'category.type_id = :value',
         parameters: { value },
       };
     }

--- a/api/rest/src/categories/entities/category.entity.ts
+++ b/api/rest/src/categories/entities/category.entity.ts
@@ -12,7 +12,6 @@ import {
 import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { CoreEntity } from '../../common/entities/core.entity';
 import { Attachment } from '../../common/entities/attachment.entity';
-import { Type } from 'src/types/entities/type.entity';
 
 @Entity('categories')
 export class Category extends CoreEntity {
@@ -56,11 +55,6 @@ export class Category extends CoreEntity {
   @OneToMany(() => Category, (category) => category.parent)
   children?: Category[];
 
-  @ApiHideProperty()
-  @ManyToOne(() => Type, { nullable: true })
-  @JoinColumn({ name: 'type_id' })
-  type?: Type;
-
   @ApiProperty({ 
     description: 'Category details', 
     required: false,
@@ -89,9 +83,10 @@ export class Category extends CoreEntity {
     description: 'Type ID', 
     example: 1,
     type: Number,
+    required: false,
   })
-  @Column()
-  type_id: number;
+  @Column({ nullable: true })
+  type_id?: number;
 
   @ApiProperty({ 
     description: 'Language code', 


### PR DESCRIPTION
Switch category relation to a simple foreign key and improve admin image handling. Removed the Type relation from Category and made type_id nullable/optional; updated categories service to stop joining the type entity and to filter by category.type_id. In the admin UI, render type_id (dataIndex/key changed) and add a getValidImageSrc util to normalize image URLs and fallbacks. Also guard the HTTP client so Authorization header is only set when a token exists.