### PR TITLE
feat: Enhance attributes API, DTOs, entities & auth

### DIFF
--- a/api/rest/src/attributes/attributes.controller.ts
+++ b/api/rest/src/attributes/attributes.controller.ts
@@ -1,4 +1,3 @@
-// attributes/attributes.controller.ts
 import {
   Controller,
   Get,
@@ -9,14 +8,11 @@ import {
   Delete,
   Query,
   UseGuards,
-  HttpCode,
-  HttpStatus,
   ParseIntPipe,
 } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
-  ApiResponse,
   ApiBearerAuth,
   ApiBody,
   ApiParam,
@@ -37,9 +33,10 @@ import { Attribute } from './entities/attribute.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
-import { Permission } from '../common/enums/enums';
+import { Permission, SortOrder } from '../common/enums/enums';
 import { Roles } from '../common/decorators/roles.decorator';
 import { Public } from '../common/decorators/public.decorator';
+import { AttributeOrderByColumn } from 'src/common/enums/attribute-order-by.enum';
 
 @ApiTags('🏷️ Attributes')
 @Controller('attributes')
@@ -56,7 +53,7 @@ export class AttributesController {
   })
   @ApiCreatedResponse({
     description: 'Attribute created successfully',
-    type: Attribute,
+    type: () => Attribute,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
@@ -74,10 +71,8 @@ export class AttributesController {
   })
   @ApiOkResponse({
     description: 'Attributes retrieved successfully',
-    type: [Attribute],
+    type: () => [Attribute],
   })
-  @ApiQuery({ name: 'shop_id', required: false, type: Number })
-  @ApiQuery({ name: 'language', required: false, type: String })
   findAll(@Query() args: GetAttributesArgs): Promise<Attribute[]> {
     return this.attributesService.findAll(args);
   }
@@ -92,13 +87,13 @@ export class AttributesController {
     name: 'param',
     description: 'Attribute ID or slug',
     example: '1 or color',
+    type: String,
   })
   @ApiOkResponse({
     description: 'Attribute retrieved successfully',
-    type: Attribute,
+    type: () => Attribute,
   })
   @ApiNotFoundResponse({ description: 'Attribute not found' })
-  @ApiQuery({ name: 'language', required: false, type: String })
   findOne(
     @Param('param') param: string,
     @Query() args: GetAttributeArgs,
@@ -112,10 +107,10 @@ export class AttributesController {
     summary: 'Update attribute',
     description: 'Update attribute information by ID (Admin/Store Owner only)',
   })
-  @ApiParam({ name: 'id', description: 'Attribute ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Attribute ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Attribute updated successfully',
-    type: Attribute,
+    type: () => Attribute,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiNotFoundResponse({ description: 'Attribute not found' })
@@ -132,10 +127,9 @@ export class AttributesController {
   @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER)
   @ApiOperation({
     summary: 'Delete attribute',
-    description:
-      'Permanently delete an attribute by ID (Admin/Store Owner only)',
+    description: 'Soft delete an attribute by ID (Admin/Store Owner only)',
   })
-  @ApiParam({ name: 'id', description: 'Attribute ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Attribute ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Attribute deleted successfully',
     type: CoreMutationOutput,

--- a/api/rest/src/attributes/attributes.module.ts
+++ b/api/rest/src/attributes/attributes.module.ts
@@ -1,4 +1,3 @@
-// attributes/attributes.module.ts
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AttributesService } from './attributes.service';
@@ -7,9 +6,7 @@ import { Attribute } from './entities/attribute.entity';
 import { AttributeValue } from './entities/attribute-value.entity';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Attribute, AttributeValue]), // Add this line
-  ],
+  imports: [TypeOrmModule.forFeature([Attribute, AttributeValue])],
   controllers: [AttributesController],
   providers: [AttributesService],
   exports: [AttributesService],

--- a/api/rest/src/attributes/attributes.service.ts
+++ b/api/rest/src/attributes/attributes.service.ts
@@ -1,4 +1,3 @@
-// attributes/attributes.service.ts
 import {
   Injectable,
   NotFoundException,
@@ -6,16 +5,15 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import {
-  CreateAttributeDto,
-  AttributeValueDto,
-} from './dto/create-attribute.dto';
+import { CreateAttributeDto, AttributeValueDto } from './dto/create-attribute.dto';
 import { UpdateAttributeDto } from './dto/update-attribute.dto';
 import { GetAttributesArgs } from './dto/get-attributes.dto';
 import { Attribute } from './entities/attribute.entity';
 import { AttributeValue } from './entities/attribute-value.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
+import { SortOrder } from 'src/common/enums/enums';
+import { AttributeOrderByColumn } from 'src/common/enums/attribute-order-by.enum';
+
 
 @Injectable()
 export class AttributesService {
@@ -27,25 +25,44 @@ export class AttributesService {
   ) {}
 
   async create(createAttributeDto: CreateAttributeDto): Promise<Attribute> {
-    // Check if attribute with same name exists in shop
+    const language = createAttributeDto.language || 'en';
+    
+    // Check if attribute exists
     const existing = await this.attributeRepository.findOne({
       where: {
         name: createAttributeDto.name,
         shop_id: createAttributeDto.shop_id,
-        language: createAttributeDto.language || 'en',
+        language: language,
       },
+      relations: ['values'],
     });
 
+    // If exists, update values and return
     if (existing) {
-      throw new ConflictException(
-        'Attribute with this name already exists in this shop',
-      );
+      if (createAttributeDto.values && createAttributeDto.values.length > 0) {
+        // Delete old values
+        await this.attributeValueRepository.delete({ attribute_id: existing.id });
+        
+        // Create new values
+        const values = createAttributeDto.values.map((val) =>
+          this.attributeValueRepository.create({
+            value: val.value,
+            meta: val.meta,
+            language: val.language || 'en',
+            shop_id: parseInt(existing.shop_id),
+            attribute_id: existing.id,
+            translated_languages: [val.language || 'en'],
+          }),
+        );
+        
+        await this.attributeValueRepository.save(values);
+      }
+      return this.findOne(existing.id.toString());
     }
 
-    // Generate slug from name
+    // Create new attribute
     const slug = this.generateSlug(createAttributeDto.name);
 
-    // Create new attribute
     const attribute = this.attributeRepository.create({
       name: createAttributeDto.name,
       shop_id: createAttributeDto.shop_id,
@@ -56,7 +73,6 @@ export class AttributesService {
 
     const savedAttribute = await this.attributeRepository.save(attribute);
 
-    // Create attribute values
     if (createAttributeDto.values && createAttributeDto.values.length > 0) {
       const values = createAttributeDto.values.map((val) =>
         this.attributeValueRepository.create({
@@ -96,14 +112,30 @@ export class AttributesService {
       );
     }
 
-    // Apply ordering
-    if (args.orderBy && args.orderBy.length > 0) {
-      const [orderBy] = args.orderBy;
-      const column = orderBy.column.toLowerCase();
+    const orderByClause =
+      args.orderBy && args.orderBy.length > 0
+        ? args.orderBy[0]
+        : args.column
+          ? {
+              column: args.column,
+              order: args.order || SortOrder.DESC,
+            }
+          : null;
 
-      // Convert SortOrder enum to string literal expected by TypeORM
-      const orderDirection = orderBy.order === SortOrder.ASC ? 'ASC' : 'DESC';
-      queryBuilder.orderBy(`attribute.${column}`, orderDirection);
+    if (orderByClause) {
+      let column: string;
+      switch (orderByClause.column) {
+        case AttributeOrderByColumn.NAME:
+          column = 'attribute.name';
+          break;
+        case AttributeOrderByColumn.UPDATED_AT:
+          column = 'attribute.updated_at';
+          break;
+        default:
+          column = 'attribute.created_at';
+      }
+      const orderDirection = orderByClause.order === SortOrder.ASC ? 'ASC' : 'DESC';
+      queryBuilder.orderBy(column, orderDirection);
     } else {
       queryBuilder.orderBy('attribute.created_at', 'DESC');
     }
@@ -112,14 +144,15 @@ export class AttributesService {
   }
 
   async findOne(param: string, language?: string): Promise<Attribute> {
-    const isId = !isNaN(Number(param));
+    const normalizedParam = this.normalizeIdOrSlugParam(param);
+    const isId = !isNaN(Number(normalizedParam));
 
     const queryBuilder = this.attributeRepository
       .createQueryBuilder('attribute')
       .leftJoinAndSelect('attribute.values', 'values')
       .where(isId ? 'attribute.id = :id' : 'attribute.slug = :slug', {
-        id: isId ? Number(param) : undefined,
-        slug: isId ? undefined : param,
+        id: isId ? Number(normalizedParam) : undefined,
+        slug: isId ? undefined : normalizedParam,
       });
 
     if (language) {
@@ -132,21 +165,57 @@ export class AttributesService {
       );
     }
 
-    const attribute = await queryBuilder.getOne();
+    let attribute = await queryBuilder.getOne();
+
+    // If the incoming value is not numeric but starts with a number
+    // (e.g. "1 or color" from Swagger placeholder-style input),
+    // try resolving by the leading id as a fallback.
+    if (!attribute && !isId) {
+      const leadingId = normalizedParam.match(/^\d+/)?.[0];
+      if (leadingId) {
+        const fallbackQuery = this.attributeRepository
+          .createQueryBuilder('attribute')
+          .leftJoinAndSelect('attribute.values', 'values')
+          .where('attribute.id = :id', { id: Number(leadingId) });
+
+        if (language) {
+          fallbackQuery.andWhere(
+            '(attribute.language = :language OR attribute.translated_languages LIKE :languageLike)',
+            {
+              language,
+              languageLike: `%${language}%`,
+            },
+          );
+        }
+
+        attribute = await fallbackQuery.getOne();
+      }
+    }
 
     if (!attribute) {
       throw new NotFoundException(
-        `Attribute with ${isId ? 'ID' : 'slug'} ${param} not found`,
+        `Attribute with ${isId ? 'ID' : 'slug'} ${normalizedParam} not found`,
       );
     }
 
     return attribute;
   }
 
-  async update(
-    id: number,
-    updateAttributeDto: UpdateAttributeDto,
-  ): Promise<Attribute> {
+  private normalizeIdOrSlugParam(param: string): string {
+    if (!param) return param;
+
+    const trimmed = param.trim();
+
+    // Swagger examples sometimes get pasted literally as "1 or color".
+    const placeholderLike = /^\d+\s+or\s+/i;
+    if (placeholderLike.test(trimmed)) {
+      return trimmed.split(/\s+or\s+/i)[0].trim();
+    }
+
+    return trimmed;
+  }
+
+  async update(id: number, updateAttributeDto: UpdateAttributeDto): Promise<Attribute> {
     const attribute = await this.attributeRepository.findOne({
       where: { id },
       relations: ['values'],
@@ -156,7 +225,6 @@ export class AttributesService {
       throw new NotFoundException(`Attribute with ID ${id} not found`);
     }
 
-    // Update fields
     if (updateAttributeDto.name) {
       attribute.name = updateAttributeDto.name;
       attribute.slug = this.generateSlug(updateAttributeDto.name);
@@ -168,21 +236,16 @@ export class AttributesService {
 
     if (updateAttributeDto.language) {
       attribute.language = updateAttributeDto.language;
-      if (
-        !attribute.translated_languages.includes(updateAttributeDto.language)
-      ) {
+      if (!attribute.translated_languages.includes(updateAttributeDto.language)) {
         attribute.translated_languages.push(updateAttributeDto.language);
       }
     }
 
     await this.attributeRepository.save(attribute);
 
-    // Update values if provided
     if (updateAttributeDto.values) {
-      // Delete existing values
-      await this.attributeValueRepository.delete({ attribute_id: id });
+      await this.attributeValueRepository.softDelete({ attribute_id: id });
 
-      // Create new values
       const newValues = updateAttributeDto.values.map((val) =>
         this.attributeValueRepository.create({
           value: val.value,
@@ -209,7 +272,7 @@ export class AttributesService {
       throw new NotFoundException(`Attribute with ID ${id} not found`);
     }
 
-    await this.attributeRepository.remove(attribute);
+    await this.attributeRepository.softDelete(id);
 
     return {
       success: true,

--- a/api/rest/src/attributes/dto/attribute-response.dto.ts
+++ b/api/rest/src/attributes/dto/attribute-response.dto.ts
@@ -1,49 +1,48 @@
-// attributes/dto/attribute-response.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { Attribute } from '../entities/attribute.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 
 export class AttributeResponse {
-  @ApiProperty({ type: Attribute })
+  @ApiProperty({ type: () => Attribute, description: 'Attribute data' })
   attribute: Attribute;
 }
 
 export class AttributeMutationResponse extends CoreMutationOutput {
-  @ApiProperty({ type: Attribute, required: false })
+  @ApiProperty({ type: () => Attribute, required: false, description: 'Updated attribute data' })
   attribute?: Attribute;
 }
 
 export class AttributePaginator {
-  @ApiProperty({ type: [Attribute] })
+  @ApiProperty({ type: () => [Attribute], description: 'Array of attributes' })
   data: Attribute[];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Current page number' })
   current_page: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number, description: 'Items per page' })
   per_page: number;
 
-  @ApiProperty({ example: 100 })
+  @ApiProperty({ example: 100, type: Number, description: 'Total items count' })
   total: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Last page number' })
   last_page: number;
 
-  @ApiProperty({ example: '/attributes?page=1' })
+  @ApiProperty({ example: '/attributes?page=1', type: String, description: 'First page URL' })
   first_page_url: string;
 
-  @ApiProperty({ example: '/attributes?page=10' })
+  @ApiProperty({ example: '/attributes?page=10', type: String, description: 'Last page URL' })
   last_page_url: string;
 
-  @ApiProperty({ example: '/attributes?page=2', nullable: true })
+  @ApiProperty({ example: '/attributes?page=2', nullable: true, type: String, description: 'Next page URL' })
   next_page_url: string | null;
 
-  @ApiProperty({ example: '/attributes?page=1', nullable: true })
+  @ApiProperty({ example: '/attributes?page=1', nullable: true, type: String, description: 'Previous page URL' })
   prev_page_url: string | null;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Starting item index' })
   from: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number, description: 'Ending item index' })
   to: number;
 }

--- a/api/rest/src/attributes/dto/create-attribute.dto.ts
+++ b/api/rest/src/attributes/dto/create-attribute.dto.ts
@@ -1,5 +1,4 @@
-// attributes/dto/create-attribute.dto.ts
-import { ApiProperty, PickType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsArray,
   IsNotEmpty,
@@ -9,57 +8,46 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { Attribute } from '../entities/attribute.entity';
 
 export class AttributeValueDto {
-  @ApiProperty({
-    description: 'Attribute value ID',
-    example: 1,
-    required: false,
-  })
+  @ApiProperty({ description: 'Attribute value ID', example: 1, required: false, type: Number })
   @IsNumber()
   @IsOptional()
   id?: number;
 
-  @ApiProperty({
-    description: 'Attribute value',
-    example: 'Red',
-    required: true,
-  })
+  @ApiProperty({ description: 'Attribute value', example: 'Red', required: true, type: String })
   @IsString()
   @IsNotEmpty()
   value: string;
 
-  @ApiProperty({
-    description: 'Meta information (e.g., color code)',
-    example: '#FF0000',
-    required: false,
-  })
+  @ApiProperty({ description: 'Meta information (e.g., color code)', example: '#FF0000', required: false, type: String })
   @IsString()
   @IsOptional()
   meta?: string;
 
-  @ApiProperty({
-    description: 'Language code',
-    example: 'en',
-    required: false,
-    default: 'en',
-  })
+  @ApiProperty({ description: 'Language code', example: 'en', required: false, default: 'en', type: String })
   @IsString()
   @IsOptional()
-  language?: string;
+  language?: string = 'en';
 }
 
-export class CreateAttributeDto extends PickType(Attribute, [
-  'name',
-  'shop_id',
-  'language',
-] as const) {
-  @ApiProperty({
-    description: 'Attribute values',
-    type: [AttributeValueDto],
-    required: true,
-  })
+export class CreateAttributeDto {
+  @ApiProperty({ description: 'Attribute name', example: 'Color', type: String })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ description: 'Shop ID', example: '1', type: String })
+  @IsString()
+  @IsNotEmpty()
+  shop_id: string;
+
+  @ApiProperty({ description: 'Language code', example: 'en', required: false, default: 'en', type: String })
+  @IsString()
+  @IsOptional()
+  language?: string = 'en';
+
+  @ApiProperty({ description: 'Attribute values', type: () => [AttributeValueDto], required: true })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => AttributeValueDto)

--- a/api/rest/src/attributes/dto/get-attribute.dto.ts
+++ b/api/rest/src/attributes/dto/get-attribute.dto.ts
@@ -1,26 +1,21 @@
-// attributes/dto/get-attribute.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsNumber, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class GetAttributeArgs {
-  @ApiProperty({
-    description: 'Attribute ID',
-    example: 1,
-    required: false,
-  })
+  @ApiProperty({ description: 'Attribute ID', example: 1, required: false, type: Number })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   id?: number;
 
-  @ApiProperty({
-    description: 'Attribute slug',
-    example: 'color',
-    required: false,
-  })
+  @ApiProperty({ description: 'Attribute slug', example: 'color', required: false, type: String })
+  @IsOptional()
+  @IsString()
   slug?: string;
 
-  @ApiProperty({
-    description: 'Language code',
-    example: 'en',
-    required: false,
-    default: 'en',
-  })
-  language?: string;
+  @ApiProperty({ description: 'Language code', example: 'en', required: false, default: 'en', type: String })
+  @IsOptional()
+  @IsString()
+  language?: string = 'en';
 }

--- a/api/rest/src/attributes/dto/get-attributes.dto.ts
+++ b/api/rest/src/attributes/dto/get-attributes.dto.ts
@@ -1,42 +1,56 @@
-// attributes/dto/get-attributes.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
-import { QueryAttributesOrderByColumn } from '../../common/enums/enums';
+import { IsOptional, IsNumber, IsString, IsArray, ValidateNested, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SortOrder } from 'src/common/enums/enums';
+import { AttributeOrderByColumn } from 'src/common/enums/attribute-order-by.enum';
+
 
 export class QueryAttributesOrderByOrderByClause {
-  @ApiProperty({
-    enum: QueryAttributesOrderByColumn,
-    example: QueryAttributesOrderByColumn.NAME,
-  })
-  column: QueryAttributesOrderByColumn;
+  @ApiProperty({ enum: AttributeOrderByColumn, example: AttributeOrderByColumn.NAME })
+  @IsEnum(AttributeOrderByColumn)
+  column: AttributeOrderByColumn;
 
-  @ApiProperty({
-    enum: SortOrder,
-    example: SortOrder.ASC,
-  })
+  @ApiProperty({ enum: SortOrder, example: SortOrder.ASC })
+  @IsEnum(SortOrder)
   order: SortOrder;
 }
 
 export class GetAttributesArgs {
-  @ApiProperty({
-    type: [QueryAttributesOrderByOrderByClause],
-    required: false,
-    description: 'Order by clauses',
-  })
+  @ApiProperty({ type: [QueryAttributesOrderByOrderByClause], required: false, description: 'Order by clauses' })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => QueryAttributesOrderByOrderByClause)
   orderBy?: QueryAttributesOrderByOrderByClause[];
 
-  @ApiProperty({
-    description: 'Filter by shop ID',
-    example: 1,
-    required: false,
-  })
+  @ApiProperty({ description: 'Filter by shop ID', example: 1, required: false, type: Number })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   shop_id?: number;
 
+  @ApiProperty({ description: 'Language code', example: 'en', required: false, default: 'en', type: String })
+  @IsOptional()
+  @IsString()
+  language?: string = 'en';
+
   @ApiProperty({
-    description: 'Language code',
-    example: 'en',
+    enum: AttributeOrderByColumn,
     required: false,
-    default: 'en',
+    description: 'Flat sort column (Swagger compatibility)',
+    example: AttributeOrderByColumn.NAME,
   })
-  language?: string;
+  @IsOptional()
+  @IsEnum(AttributeOrderByColumn)
+  column?: AttributeOrderByColumn;
+
+  @ApiProperty({
+    enum: SortOrder,
+    required: false,
+    description: 'Flat sort order (Swagger compatibility)',
+    example: SortOrder.ASC,
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  order?: SortOrder;
 }

--- a/api/rest/src/attributes/dto/update-attribute.dto.ts
+++ b/api/rest/src/attributes/dto/update-attribute.dto.ts
@@ -1,4 +1,3 @@
-// attributes/dto/update-attribute.dto.ts
 import { PartialType } from '@nestjs/swagger';
 import { CreateAttributeDto } from './create-attribute.dto';
 

--- a/api/rest/src/attributes/entities/attribute-value.entity.ts
+++ b/api/rest/src/attributes/entities/attribute-value.entity.ts
@@ -1,70 +1,46 @@
-// attributes/entities/attribute-value.entity.ts
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { CoreEntity } from 'src/common/entities/core.entity';
-import { Attribute } from './attribute.entity';
-import { Entity, Column, ManyToOne, JoinColumn } from 'typeorm';
+import type { Attribute } from './attribute.entity';
+import { Entity, Column, ManyToOne, JoinColumn, DeleteDateColumn } from 'typeorm';
 
 @Entity('attribute_values')
 export class AttributeValue extends CoreEntity {
-  @ApiProperty({
-    description: 'Shop ID',
-    example: 1,
-  })
+  @ApiProperty({ description: 'Shop ID', example: 1, type: Number })
   @Column()
   shop_id: number;
 
-  @ApiProperty({
-    description: 'Attribute value',
-    example: 'Red',
-  })
+  @ApiProperty({ description: 'Attribute value', example: 'Red', type: String })
   @Column()
   value: string;
 
-  @ApiProperty({
-    description: 'Meta information (e.g., color code)',
-    example: '#FF0000',
-    required: false,
-  })
+  @ApiProperty({ description: 'Meta information (e.g., color code)', example: '#FF0000', required: false, type: String })
   @Column({ nullable: true })
   meta?: string;
 
-  @ApiProperty({
-    description: 'Attribute value slug (legacy field)',
-    example: 'red',
-    required: false,
-  })
+  @ApiProperty({ description: 'Attribute value slug', example: 'red', required: false, type: String })
   @Column({ nullable: true })
   slug?: string;
 
-  @ApiProperty({
-    type: () => Attribute,
-    description: 'Parent attribute',
-  })
-  @ManyToOne(() => Attribute, (attribute) => attribute.values, {
+  @ApiHideProperty()
+  @ManyToOne(() => require('./attribute.entity').Attribute, (attribute: Attribute) => attribute.values, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'attribute_id' })
   attribute: Attribute;
 
-  @ApiProperty({
-    description: 'Attribute ID',
-    example: 1,
-  })
+  @ApiProperty({ description: 'Attribute ID', example: 1, type: Number })
   @Column()
   attribute_id: number;
 
-  @ApiProperty({
-    description: 'Language code',
-    example: 'en',
-  })
+  @ApiProperty({ description: 'Language code', example: 'en', type: String, default: 'en' })
   @Column({ default: 'en' })
   language: string;
 
-  @ApiProperty({
-    description: 'Translated languages',
-    example: ['en', 'es'],
-    type: [String],
-  })
+  @ApiProperty({ description: 'Translated languages', type: [String], example: ['en', 'es', 'fr'] })
   @Column('simple-array', { nullable: true })
   translated_languages: string[];
+
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
 }

--- a/api/rest/src/attributes/entities/attribute.entity.ts
+++ b/api/rest/src/attributes/entities/attribute.entity.ts
@@ -1,68 +1,37 @@
-// attributes/entities/attribute.entity.ts
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { CoreEntity } from 'src/common/entities/core.entity';
-import { Shop } from 'src/shops/entities/shop.entity';
-import { AttributeValue } from './attribute-value.entity';
-import { Entity, Column, OneToMany } from 'typeorm';
+import type { AttributeValue } from './attribute-value.entity';
+import { Entity, Column, OneToMany, DeleteDateColumn } from 'typeorm';
 
 @Entity('attributes')
 export class Attribute extends CoreEntity {
-  @ApiProperty({
-    description: 'Attribute name',
-    example: 'Color',
-  })
+  @ApiProperty({ description: 'Attribute name', example: 'Color', type: String })
   @Column()
   name: string;
 
-  @ApiProperty({
-    description: 'Shop ID',
-    example: '1',
-  })
+  @ApiProperty({ description: 'Shop ID', example: '1', type: String })
   @Column()
   shop_id: string;
 
-  @ApiProperty({
-    type: () => Shop,
-    description: 'Shop details',
-    required: false,
-  })
-  shop?: Shop;
-
-  @ApiProperty({
-    description: 'Attribute slug',
-    example: 'color',
-  })
+  @ApiProperty({ description: 'Attribute slug', example: 'color', type: String })
   @Column()
   slug: string;
 
-  @ApiProperty({
-    type: [AttributeValue],
-    description: 'Attribute values',
-  })
-  @OneToMany(() => AttributeValue, (value) => value.attribute, {
+  @ApiProperty({ type: () => [require('./attribute-value.entity').AttributeValue], description: 'Attribute values' })
+  @OneToMany(() => require('./attribute-value.entity').AttributeValue, (value: AttributeValue) => value.attribute, {
     cascade: true,
   })
   values: AttributeValue[];
 
-  @ApiProperty({
-    description: 'Language code',
-    example: 'en',
-  })
+  @ApiProperty({ description: 'Language code', example: 'en', type: String, default: 'en' })
   @Column({ default: 'en' })
   language: string;
 
-  @ApiProperty({
-    description: 'Translated languages',
-    example: ['en', 'es'],
-    type: [String],
-  })
+  @ApiProperty({ description: 'Translated languages', type: [String], example: ['en', 'es', 'fr'] })
   @Column('simple-array', { nullable: true })
   translated_languages: string[];
 
-  @ApiProperty({
-    description: 'Type information (legacy field)',
-    required: false,
-  })
+  @ApiProperty({ description: 'Type information (legacy field)', required: false, type: Object })
   @Column('json', { nullable: true })
   type?: {
     id: number | null;
@@ -70,4 +39,8 @@ export class Attribute extends CoreEntity {
     slug: string | null;
     logo: string | null;
   };
+
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
 }

--- a/api/rest/src/auth/strategies/jwt.strategy.ts
+++ b/api/rest/src/auth/strategies/jwt.strategy.ts
@@ -9,15 +9,30 @@ import { UsersService } from 'src/users/users.service';
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(private usersService: UsersService) {
     super({
-      // Robust extractor: handles headers like "Bearer <token>" and
-      // accidental duplicates like "Bearer Bearer <token>" that some
-      // Swagger clients produce when the user pastes the full "Bearer <token>".
+      // Robust extractor for Swagger/manual auth input.
       jwtFromRequest: (req: any) => {
-        const header = req?.headers?.authorization;
-        if (!header) return null;
-        // Remove all occurrences of the literal "Bearer" (case-insensitive)
-        // then trim to obtain the raw token value.
-        return header.replace(/Bearer\s+/gi, '').trim();
+        const headerValue = req?.headers?.authorization;
+        if (!headerValue || typeof headerValue !== 'string') return null;
+
+        let token = headerValue.trim();
+
+        // Remove repeated "Bearer " prefixes (Swagger users often paste the full value).
+        token = token.replace(/^(?:Bearer\s+)+/i, '').trim();
+
+        // Remove accidental surrounding quotes.
+        token = token.replace(/^"|"$/g, '').replace(/^'|'$/g, '').trim();
+
+        // Support accidentally pasted JSON auth response.
+        if (token.startsWith('{') && token.endsWith('}')) {
+          try {
+            const parsed = JSON.parse(token);
+            token = parsed?.token || parsed?.accessToken || '';
+          } catch {
+            return null;
+          }
+        }
+
+        return token || null;
       },
       ignoreExpiration: false,
       secretOrKey: jwtConfig.secret,
@@ -25,10 +40,25 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   async validate(payload: any) {
-    const user = await this.usersService.findOne(payload.sub);
+    let user = null;
+
+    const userId = Number(payload?.sub);
+    if (Number.isFinite(userId)) {
+      try {
+        user = await this.usersService.findOne(userId);
+      } catch {
+        user = null;
+      }
+    }
+
+    if (!user && payload?.email) {
+      user = await this.usersService.findByEmail(payload.email);
+    }
+
     if (!user) {
       throw new UnauthorizedException();
     }
+
     return user;
   }
 }

--- a/api/rest/src/common/enums/attribute-order-by.enum.ts
+++ b/api/rest/src/common/enums/attribute-order-by.enum.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum AttributeOrderByColumn {
+  CREATED_AT = 'created_at',
+  UPDATED_AT = 'updated_at',
+  NAME = 'name',
+}

--- a/api/rest/src/users/entities/profile.entity.ts
+++ b/api/rest/src/users/entities/profile.entity.ts
@@ -9,7 +9,7 @@ import {
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { CoreEntity } from 'src/common/entities/core.entity';
-import { User } from './user.entity';
+import type { User } from './user.entity';
 
 @Entity('profiles')
 export class Profile extends CoreEntity {
@@ -50,8 +50,8 @@ export class Profile extends CoreEntity {
   @Column({ nullable: true })
   contact?: string;
 
-  @ApiProperty({ type: () => User, description: 'Associated user' })
-  @OneToOne(() => User, (user) => user.profile)
+  @ApiProperty({ type: () => require('./user.entity').User, description: 'Associated user' })
+  @OneToOne(() => require('./user.entity').User, (user: User) => user.profile)
   customer?: User;
 
   @ApiProperty({ description: 'Creation timestamp' })

--- a/api/rest/src/users/entities/user.entity.ts
+++ b/api/rest/src/users/entities/user.entity.ts
@@ -14,7 +14,7 @@ import {
 import { Exclude } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { Address } from 'src/addresses/entities/address.entity';
-import { Profile } from './profile.entity';
+import type { Profile } from './profile.entity';
 import { Permission } from '../../common/enums/enums';
 import { Question } from 'src/questions/entities/question.entity';
 import { Refund } from 'src/refunds/entities/refund.entity';
@@ -43,8 +43,8 @@ export class User {
   @Column({ default: true })
   is_active: boolean;
 
-  @ApiProperty({ type: () => Profile, description: 'User profile' })
-  @OneToOne(() => Profile, (profile) => profile.customer, {
+  @ApiProperty({ type: () => require('./profile.entity').Profile, description: 'User profile' })
+  @OneToOne(() => require('./profile.entity').Profile, (profile: Profile) => profile.customer, {
     cascade: true,
     eager: false,
   })


### PR DESCRIPTION
Multiple improvements across attributes, DTOs, entities, and auth handling:

- Attributes controller: improved Swagger decorators (use thunks for types, add examples), introduced AttributeOrderByColumn usage, cleaned queries.
- Attributes service: support updating existing attribute values when creating duplicates, generate slugs, normalize mixed id/slug params (handles "1 or color"), improved order-by handling using AttributeOrderByColumn and SortOrder, switch to soft deletes for attributes and values, add relations handling and fallback lookup.
- DTOs: stronger validation (class-validator/class-transformer), default language values, reworked CreateAttributeDto (explicit fields instead of PickType), clearer Swagger metadata.
- Entities: add soft-delete column (deleted_at) to attributes and attribute_values, avoid circular type imports by using require() and type-only imports, hide relation properties from Swagger where appropriate, tweak ApiProperty metadata.
- Auth: make JWT extractor robust (handles repeated Bearer prefixes, quoted tokens, JSON payloads) and validation falls back to email lookup when needed.
- Add new enum file: AttributeOrderByColumn for ordering columns.
- Minor tidyups: module formatting and small swagger/docs tweaks.

These changes improve robustness, validation, API docs, soft-delete behavior, and ordering support.