### PR TITLE
feat: Ai add status enum, validations & refactor

### DIFF
--- a/api/rest/src/ai/ai.controller.ts
+++ b/api/rest/src/ai/ai.controller.ts
@@ -1,17 +1,24 @@
-// ai/ai.controller.ts
 import { Body, Controller, Post, HttpCode, HttpStatus } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
-  ApiResponse,
+  ApiBearerAuth,
   ApiBody,
   ApiBadRequestResponse,
   ApiOkResponse,
   ApiInternalServerErrorResponse,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
 } from '@nestjs/swagger';
 import { AiService } from './ai.service';
 import { CreateAiDto } from './dto/create-ai.dto';
 import { AiResponseDto } from './dto/ai-response.dto';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
+import { UseGuards } from '@nestjs/common';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Permission } from '../common/enums/enums';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('🤖 AI Integration')
 @Controller('ai')
@@ -19,23 +26,30 @@ export class AiController {
   constructor(private readonly aiService: AiService) {}
 
   @Post('generate-descriptions')
+  @Public()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Generate AI descriptions',
-    description:
-      'Generate product or content descriptions using AI based on the provided prompt',
+    description: 'Generate product or content descriptions using AI based on the provided prompt',
   })
   @ApiOkResponse({
     description: 'Description generated successfully',
-    type: AiResponseDto,
+    type: () => AiResponseDto,
+    schema: {
+      example: {
+        status: 'success',
+        result: 'This is a generated description for your product...',
+      },
+    },
   })
   @ApiBadRequestResponse({
     description: 'Invalid prompt provided',
     schema: {
       type: 'object',
       properties: {
-        status: { type: 'string', example: 'failed' },
-        error: { type: 'string', example: 'Prompt cannot be empty' },
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'string', example: 'Prompt cannot be empty' },
+        error: { type: 'string', example: 'Bad Request' },
       },
     },
   })
@@ -44,8 +58,9 @@ export class AiController {
     schema: {
       type: 'object',
       properties: {
-        status: { type: 'string', example: 'failed' },
-        error: { type: 'string', example: 'AI service unavailable' },
+        statusCode: { type: 'number', example: 500 },
+        message: { type: 'string', example: 'Failed to generate description' },
+        error: { type: 'string', example: 'Internal Server Error' },
       },
     },
   })
@@ -55,15 +70,22 @@ export class AiController {
     examples: {
       product_description: {
         summary: 'Generate product description',
+        description: 'Example for generating a product description',
         value: { prompt: 'Generate a description for a wireless gaming mouse' },
       },
       blog_post: {
         summary: 'Generate blog post',
+        description: 'Example for generating a blog post',
         value: { prompt: 'Write a blog post about healthy eating habits' },
+      },
+      seo_meta: {
+        summary: 'Generate SEO meta description',
+        description: 'Example for generating SEO meta description',
+        value: { prompt: 'Generate SEO meta description for an e-commerce website' },
       },
     },
   })
-  create(@Body() createAiDto: CreateAiDto): Promise<AiResponseDto> {
-    return this.aiService.create(createAiDto);
+  generate(@Body() createAiDto: CreateAiDto): Promise<AiResponseDto> {
+    return this.aiService.generate(createAiDto);
   }
 }

--- a/api/rest/src/ai/ai.module.ts
+++ b/api/rest/src/ai/ai.module.ts
@@ -1,4 +1,3 @@
-// ai/ai.module.ts
 import { Module } from '@nestjs/common';
 import { AiController } from './ai.controller';
 import { AiService } from './ai.service';

--- a/api/rest/src/ai/ai.service.ts
+++ b/api/rest/src/ai/ai.service.ts
@@ -1,4 +1,3 @@
-// ai/ai.service.ts
 import {
   Injectable,
   BadRequestException,
@@ -6,10 +5,12 @@ import {
 } from '@nestjs/common';
 import { CreateAiDto } from './dto/create-ai.dto';
 import { AiResponseDto } from './dto/ai-response.dto';
+import { AiStatus } from 'src/common/enums/ai-status.enum';
+
 
 @Injectable()
 export class AiService {
-  async create(createAiDto: CreateAiDto): Promise<AiResponseDto> {
+  async generate(createAiDto: CreateAiDto): Promise<AiResponseDto> {
     try {
       // Validate input
       if (!createAiDto.prompt || createAiDto.prompt.trim().length === 0) {
@@ -17,17 +18,18 @@ export class AiService {
       }
 
       if (createAiDto.prompt.length < 3) {
-        throw new BadRequestException(
-          'Prompt must be at least 3 characters long',
-        );
+        throw new BadRequestException('Prompt must be at least 3 characters long');
+      }
+
+      if (createAiDto.prompt.length > 500) {
+        throw new BadRequestException('Prompt cannot exceed 500 characters');
       }
 
       // Simulate AI processing
-      // In a real implementation, you would call an AI service here
       const generatedResult = await this.generateAIResponse(createAiDto.prompt);
 
       return {
-        status: 'success',
+        status: AiStatus.SUCCESS,
         result: generatedResult,
       };
     } catch (error) {
@@ -39,22 +41,27 @@ export class AiService {
       console.error('AI Service Error:', error);
 
       throw new InternalServerErrorException({
-        status: 'failed',
+        status: AiStatus.FAILED,
         error: 'Failed to generate description. Please try again later.',
       });
     }
   }
 
   private async generateAIResponse(prompt: string): Promise<string> {
-    // Simulate async AI processing
-    // In production, replace this with actual AI API call
+    // Simulate async AI processing with more realistic responses
     return new Promise((resolve) => {
       setTimeout(() => {
-        resolve(
-          `This is a dummy response for prompt: "${prompt.substring(0, 50)}${
-            prompt.length > 50 ? '...' : ''
-          }"`,
-        );
+        const responses = [
+          `✨ AI Generated: Based on your prompt "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}", here is a creative and engaging description that captures the essence of your product. This high-quality item features premium materials, innovative design, and exceptional performance. Perfect for customers seeking reliability and style. Order now and experience the difference!`,
+
+          `🚀 Generated Content: Your prompt "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}" has been processed. This product offers outstanding value with its cutting-edge features, durable construction, and user-friendly interface. Whether you're a beginner or expert, this item delivers consistent results. Don't miss out on this amazing opportunity!`,
+
+          `💡 AI Response: For "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}", here's your personalized description. This exceptional product combines functionality with elegance, making it a must-have for modern lifestyles. With positive reviews from satisfied customers, you can trust in its quality and performance. Get yours today and elevate your experience!`,
+        ];
+
+        // Select a random response for variety
+        const randomIndex = Math.floor(Math.random() * responses.length);
+        resolve(responses[randomIndex]);
       }, 500);
     });
   }

--- a/api/rest/src/ai/dto/ai-response.dto.ts
+++ b/api/rest/src/ai/dto/ai-response.dto.ts
@@ -1,18 +1,20 @@
-// ai/dto/ai-response.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
+import { AiStatus } from 'src/common/enums/ai-status.enum';
 
 export class AiResponseDto {
   @ApiProperty({
     description: 'AI generation status',
-    enum: ['success', 'failed'],
-    example: 'success',
+    enum: AiStatus,
+    example: AiStatus.SUCCESS,
+    type: String,
   })
-  status: 'success' | 'failed';
+  status: AiStatus;
 
   @ApiProperty({
     description: 'Generated content from AI',
     example: 'This is a dummy response for dummy API.',
     required: false,
+    type: String,
   })
   result?: string;
 
@@ -20,6 +22,7 @@ export class AiResponseDto {
     description: 'Error message if generation failed',
     example: 'Failed to generate description',
     required: false,
+    type: String,
   })
   error?: string;
 }

--- a/api/rest/src/ai/dto/create-ai.dto.ts
+++ b/api/rest/src/ai/dto/create-ai.dto.ts
@@ -1,14 +1,18 @@
-// ai/dto/create-ai.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
 
 export class CreateAiDto {
   @ApiProperty({
     description: 'Prompt for AI description generation',
     example: 'Generate a product description for a wireless mouse',
     required: true,
+    type: String,
+    minLength: 3,
+    maxLength: 500,
   })
   @IsString()
   @IsNotEmpty()
+  @MinLength(3, { message: 'Prompt must be at least 3 characters long' })
+  @MaxLength(500, { message: 'Prompt cannot exceed 500 characters' })
   prompt: string;
 }

--- a/api/rest/src/ai/entities/ai.entity.ts
+++ b/api/rest/src/ai/entities/ai.entity.ts
@@ -1,18 +1,20 @@
-// ai/entities/ai.entity.ts
 import { ApiProperty } from '@nestjs/swagger';
+import { AiStatus } from 'src/common/enums/ai-status.enum';
 
 export class Ai {
   @ApiProperty({
     description: 'AI generation status',
-    enum: ['success', 'failed'],
-    example: 'success',
+    enum: AiStatus,
+    example: AiStatus.SUCCESS,
+    type: String,
   })
-  status: 'success' | 'failed';
+  status: AiStatus;
 
   @ApiProperty({
     description: 'Generated content from AI',
     example: 'This is a dummy response for dummy API.',
     required: false,
+    type: String,
   })
   result?: string;
 
@@ -20,6 +22,7 @@ export class Ai {
     description: 'Error message if generation failed',
     example: 'Failed to generate description',
     required: false,
+    type: String,
   })
   error?: string;
 }

--- a/api/rest/src/common/enums/ai-status.enum.ts
+++ b/api/rest/src/common/enums/ai-status.enum.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum AiStatus {
+  SUCCESS = 'success',
+  FAILED = 'failed',
+}


### PR DESCRIPTION
Rename AI create -> generate endpoints and service methods; introduce AiStatus enum and use it in DTOs/entities. Add request validation (min/max length) to CreateAiDto and enforce with class-validator messages. Improve Swagger docs: response schemas, examples, and explicit types; add security/decorator imports and mark endpoint as @Public(). Enhance mocked AI responses and clean up minor file headers/formatting.