### PR TITLE
Refactor: Addresses: DTOs, entity, service, controller

### DIFF
--- a/api/rest/src/addresses/addresses.controller.ts
+++ b/api/rest/src/addresses/addresses.controller.ts
@@ -1,4 +1,3 @@
-// addresses/addresses.controller.ts
 import {
   Controller,
   Get,
@@ -12,12 +11,11 @@ import {
   HttpCode,
   HttpStatus,
   ParseIntPipe,
-  UnauthorizedException,
+  ForbiddenException,
 } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
-  ApiResponse,
   ApiBearerAuth,
   ApiBody,
   ApiParam,
@@ -37,9 +35,10 @@ import { Address } from './entities/address.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
-import { Permission } from '../common/enums/enums';
+import { Permission, SortOrder } from '../common/enums/enums';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import { Roles } from '../common/decorators/roles.decorator';
+
 
 @ApiTags('📍 Addresses')
 @Controller('address')
@@ -52,21 +51,20 @@ export class AddressesController {
   @Roles(Permission.CUSTOMER, Permission.STORE_OWNER, Permission.SUPER_ADMIN)
   @ApiOperation({
     summary: 'Create a new address',
-    description:
-      'Creates a new address for the authenticated user or specified customer',
+    description: 'Creates a new address for the authenticated user or specified customer',
   })
   @ApiCreatedResponse({
     description: 'Address created successfully',
-    type: Address,
+    type: () => Address,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @ApiBody({ type: CreateAddressDto })
-  async createAddress(
+  create(
     @Body() createAddressDto: CreateAddressDto,
     @CurrentUser() user: any,
   ): Promise<Address> {
-    // If user is not admin, use their own ID
     if (!user?.permissions?.includes(Permission.SUPER_ADMIN)) {
       createAddressDto.customer_id = user.id;
     }
@@ -85,7 +83,7 @@ export class AddressesController {
   })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
-  async addresses(@Query() query: GetAddressesDto): Promise<AddressPaginator> {
+  findAll(@Query() query: GetAddressesDto): Promise<AddressPaginator> {
     return this.addressesService.findAll(query);
   }
 
@@ -93,15 +91,14 @@ export class AddressesController {
   @Roles(Permission.CUSTOMER, Permission.STORE_OWNER)
   @ApiOperation({
     summary: 'Get my addresses',
-    description:
-      'Retrieve paginated list of addresses for the authenticated user',
+    description: 'Retrieve paginated list of addresses for the authenticated user',
   })
   @ApiOkResponse({
     description: 'Addresses retrieved successfully',
     type: AddressPaginator,
   })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
-  async myAddresses(
+  findMyAddresses(
     @Query() query: GetAddressesDto,
     @CurrentUser() user: any,
   ): Promise<AddressPaginator> {
@@ -114,27 +111,25 @@ export class AddressesController {
     summary: 'Get address by ID',
     description: 'Retrieve address details by ID',
   })
-  @ApiParam({ name: 'id', description: 'Address ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Address ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Address retrieved successfully',
-    type: Address,
+    type: () => Address,
   })
   @ApiNotFoundResponse({ description: 'Address not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
-  async address(
+  @ApiForbiddenResponse({ description: 'You do not have permission to view this address' })
+  async findOne(
     @Param('id', ParseIntPipe) id: number,
     @CurrentUser() user: any,
   ): Promise<Address> {
     const address = await this.addressesService.findOne(id);
 
-    // Check if user has permission to view this address
-    if (
-      !user?.permissions?.includes(Permission.SUPER_ADMIN) &&
-      address.customer_id !== user.id
-    ) {
-      throw new UnauthorizedException(
-        'You do not have permission to view this address',
-      );
+    const isAdmin = user?.permissions?.includes(Permission.SUPER_ADMIN);
+    const isOwner = address.customer_id === user.id;
+
+    if (!isAdmin && !isOwner) {
+      throw new ForbiddenException('You do not have permission to view this address');
     }
 
     return address;
@@ -146,30 +141,28 @@ export class AddressesController {
     summary: 'Update address',
     description: 'Update address information by ID',
   })
-  @ApiParam({ name: 'id', description: 'Address ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Address ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Address updated successfully',
-    type: Address,
+    type: () => Address,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiNotFoundResponse({ description: 'Address not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'You do not have permission to update this address' })
   @ApiBody({ type: UpdateAddressDto })
-  async updateAddress(
+  async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateAddressDto: UpdateAddressDto,
     @CurrentUser() user: any,
   ): Promise<Address> {
-    // Check if user has permission to update this address
     const address = await this.addressesService.findOne(id);
 
-    if (
-      !user?.permissions?.includes(Permission.SUPER_ADMIN) &&
-      address.customer_id !== user.id
-    ) {
-      throw new UnauthorizedException(
-        'You do not have permission to update this address',
-      );
+    const isAdmin = user?.permissions?.includes(Permission.SUPER_ADMIN);
+    const isOwner = address.customer_id === user.id;
+
+    if (!isAdmin && !isOwner) {
+      throw new ForbiddenException('You do not have permission to update this address');
     }
 
     return this.addressesService.update(id, updateAddressDto);
@@ -179,29 +172,27 @@ export class AddressesController {
   @Roles(Permission.CUSTOMER, Permission.STORE_OWNER, Permission.SUPER_ADMIN)
   @ApiOperation({
     summary: 'Delete address',
-    description: 'Permanently delete an address by ID',
+    description: 'Soft delete an address by ID',
   })
-  @ApiParam({ name: 'id', description: 'Address ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Address ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Address deleted successfully',
     type: CoreMutationOutput,
   })
   @ApiNotFoundResponse({ description: 'Address not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
-  async deleteAddress(
+  @ApiForbiddenResponse({ description: 'You do not have permission to delete this address' })
+  async remove(
     @Param('id', ParseIntPipe) id: number,
     @CurrentUser() user: any,
   ): Promise<CoreMutationOutput> {
-    // Check if user has permission to delete this address
     const address = await this.addressesService.findOne(id);
 
-    if (
-      !user?.permissions?.includes(Permission.SUPER_ADMIN) &&
-      address.customer_id !== user.id
-    ) {
-      throw new UnauthorizedException(
-        'You do not have permission to delete this address',
-      );
+    const isAdmin = user?.permissions?.includes(Permission.SUPER_ADMIN);
+    const isOwner = address.customer_id === user.id;
+
+    if (!isAdmin && !isOwner) {
+      throw new ForbiddenException('You do not have permission to delete this address');
     }
 
     return this.addressesService.remove(id);
@@ -214,13 +205,14 @@ export class AddressesController {
     summary: 'Set address as default',
     description: 'Set an address as the default address for the user',
   })
-  @ApiParam({ name: 'id', description: 'Address ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Address ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Address set as default successfully',
-    type: Address,
+    type: () => Address,
   })
   @ApiNotFoundResponse({ description: 'Address not found' })
-  async setDefaultAddress(
+  @ApiForbiddenResponse({ description: 'Address does not belong to this customer' })
+  setDefault(
     @Param('id', ParseIntPipe) id: number,
     @CurrentUser() user: any,
   ): Promise<Address> {

--- a/api/rest/src/addresses/addresses.module.ts
+++ b/api/rest/src/addresses/addresses.module.ts
@@ -1,4 +1,3 @@
-// addresses/addresses.module.ts
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AddressesService } from './addresses.service';

--- a/api/rest/src/addresses/addresses.service.ts
+++ b/api/rest/src/addresses/addresses.service.ts
@@ -1,4 +1,3 @@
-// addresses/addresses.service.ts
 import {
   Injectable,
   NotFoundException,
@@ -6,12 +5,14 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CreateAddressDto, UserAddressDto } from './dto/create-address.dto';
+import { CreateAddressDto } from './dto/create-address.dto';
 import { UpdateAddressDto } from './dto/update-address.dto';
 import { GetAddressesDto, AddressPaginator } from './dto/get-addresses.dto';
 import { Address } from './entities/address.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { paginate } from 'src/common/pagination/paginate';
+import { SortOrder } from 'src/common/enums/enums';
+import { AddressOrderByColumn } from 'src/common/enums/address-type.enum';
 
 @Injectable()
 export class AddressesService {
@@ -23,7 +24,6 @@ export class AddressesService {
   async create(createAddressDto: CreateAddressDto): Promise<Address> {
     const { customer_id, address, ...rest } = createAddressDto;
 
-    // If this is set as default, unset other default addresses for this customer
     if (rest.default) {
       await this.addressesRepository.update(
         { customer_id, default: true },
@@ -46,8 +46,8 @@ export class AddressesService {
     customer_id,
     type,
     text,
-    sortedBy = 'created_at',
-    orderBy = 'DESC',
+    orderBy = AddressOrderByColumn.CREATED_AT,
+    sortedBy = SortOrder.DESC,
   }: GetAddressesDto): Promise<AddressPaginator> {
     const query = this.addressesRepository
       .createQueryBuilder('address')
@@ -68,7 +68,20 @@ export class AddressesService {
       );
     }
 
-    query.orderBy(`address.${sortedBy}`, orderBy as 'ASC' | 'DESC');
+    let orderColumn: string;
+    switch (orderBy) {
+      case AddressOrderByColumn.TITLE:
+        orderColumn = 'address.title';
+        break;
+      case AddressOrderByColumn.UPDATED_AT:
+        orderColumn = 'address.updated_at';
+        break;
+      default:
+        orderColumn = 'address.created_at';
+    }
+
+    const orderDirection = sortedBy === SortOrder.ASC ? 'ASC' : 'DESC';
+    query.orderBy(orderColumn, orderDirection);
     query.skip((page - 1) * limit).take(limit);
 
     const [data, total] = await query.getManyAndCount();
@@ -76,7 +89,6 @@ export class AddressesService {
     const url = `/address?limit=${limit}`;
     const paginationInfo = paginate(total, page, limit, data.length, url);
 
-    // Map the pagination info to match AddressPaginator interface
     return {
       data,
       current_page: paginationInfo.current_page,
@@ -98,8 +110,8 @@ export class AddressesService {
       limit = 30,
       page = 1,
       type,
-      sortedBy = 'created_at',
-      orderBy = 'DESC',
+      orderBy = AddressOrderByColumn.CREATED_AT,
+      sortedBy = SortOrder.DESC,
     }: GetAddressesDto,
   ): Promise<AddressPaginator> {
     const query = this.addressesRepository
@@ -110,7 +122,20 @@ export class AddressesService {
       query.andWhere('address.type = :type', { type });
     }
 
-    query.orderBy(`address.${sortedBy}`, orderBy as 'ASC' | 'DESC');
+    let orderColumn: string;
+    switch (orderBy) {
+      case AddressOrderByColumn.TITLE:
+        orderColumn = 'address.title';
+        break;
+      case AddressOrderByColumn.UPDATED_AT:
+        orderColumn = 'address.updated_at';
+        break;
+      default:
+        orderColumn = 'address.created_at';
+    }
+
+    const orderDirection = sortedBy === SortOrder.ASC ? 'ASC' : 'DESC';
+    query.orderBy(orderColumn, orderDirection);
     query.skip((page - 1) * limit).take(limit);
 
     const [data, total] = await query.getManyAndCount();
@@ -118,7 +143,6 @@ export class AddressesService {
     const url = `/address/my-addresses?limit=${limit}`;
     const paginationInfo = paginate(total, page, limit, data.length, url);
 
-    // Map the pagination info to match AddressPaginator interface
     return {
       data,
       current_page: paginationInfo.current_page,
@@ -147,13 +171,9 @@ export class AddressesService {
     return address;
   }
 
-  async update(
-    id: number,
-    updateAddressDto: UpdateAddressDto,
-  ): Promise<Address> {
+  async update(id: number, updateAddressDto: UpdateAddressDto): Promise<Address> {
     const address = await this.findOne(id);
 
-    // If setting as default, unset other default addresses for this customer
     if (updateAddressDto.default && !address.default) {
       await this.addressesRepository.update(
         { customer_id: address.customer_id, default: true },
@@ -161,10 +181,8 @@ export class AddressesService {
       );
     }
 
-    // Prepare update data
     const updateData: any = { ...updateAddressDto };
 
-    // Handle address field if present
     if (updateAddressDto.address) {
       updateData.address = updateAddressDto.address;
     }
@@ -177,7 +195,7 @@ export class AddressesService {
   async remove(id: number): Promise<CoreMutationOutput> {
     const address = await this.findOne(id);
 
-    await this.addressesRepository.delete(id);
+    await this.addressesRepository.softDelete(id);
 
     return {
       success: true,
@@ -192,13 +210,11 @@ export class AddressesService {
       throw new BadRequestException('Address does not belong to this customer');
     }
 
-    // Unset all default addresses for this customer
     await this.addressesRepository.update(
       { customer_id: customerId, default: true },
       { default: false },
     );
 
-    // Set this address as default
     address.default = true;
     return this.addressesRepository.save(address);
   }

--- a/api/rest/src/addresses/dto/address-response.dto.ts
+++ b/api/rest/src/addresses/dto/address-response.dto.ts
@@ -1,49 +1,48 @@
-// addresses/dto/address-response.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { Address } from '../entities/address.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 
 export class AddressResponse {
-  @ApiProperty({ type: Address })
+  @ApiProperty({ type: () => Address, description: 'Address data' })
   address: Address;
 }
 
 export class AddressMutationResponse extends CoreMutationOutput {
-  @ApiProperty({ type: Address, required: false })
+  @ApiProperty({ type: () => Address, required: false, description: 'Updated address data' })
   address?: Address;
 }
 
 export class AddressPaginator {
-  @ApiProperty({ type: [Address] })
+  @ApiProperty({ type: () => [Address], description: 'Array of addresses' })
   data: Address[];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Current page number' })
   current_page: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Items per page' })
   per_page: number;
 
-  @ApiProperty({ example: 100 })
+  @ApiProperty({ example: 100, type: Number, description: 'Total items count' })
   total: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Last page number' })
   last_page: number;
 
-  @ApiProperty({ example: '/address?page=1' })
+  @ApiProperty({ example: '/address?page=1', type: String, description: 'First page URL' })
   first_page_url: string;
 
-  @ApiProperty({ example: '/address?page=10' })
+  @ApiProperty({ example: '/address?page=10', type: String, description: 'Last page URL' })
   last_page_url: string;
 
-  @ApiProperty({ example: '/address?page=2' })
+  @ApiProperty({ example: '/address?page=2', nullable: true, type: String, description: 'Next page URL' })
   next_page_url: string | null;
 
-  @ApiProperty({ example: '/address?page=1' })
+  @ApiProperty({ example: '/address?page=1', nullable: true, type: String, description: 'Previous page URL' })
   prev_page_url: string | null;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Starting item index' })
   from: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Ending item index' })
   to: number;
 }

--- a/api/rest/src/addresses/dto/create-address.dto.ts
+++ b/api/rest/src/addresses/dto/create-address.dto.ts
@@ -1,5 +1,4 @@
-// addresses/dto/create-address.dto.ts
-import { ApiProperty, PickType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsNotEmpty,
   IsString,
@@ -10,14 +9,14 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { Address } from '../entities/address.entity';
-import { AddressType } from '../../common/enums/enums';
+import { AddressType } from 'src/common/enums/address-type.enum';
 
-// Define UserAddressDto FIRST before using it
+
 export class UserAddressDto {
   @ApiProperty({
     description: 'Street address',
     example: '123 Main St',
+    type: String,
   })
   @IsString()
   @IsNotEmpty()
@@ -26,6 +25,7 @@ export class UserAddressDto {
   @ApiProperty({
     description: 'Country',
     example: 'United States',
+    type: String,
   })
   @IsString()
   @IsNotEmpty()
@@ -34,6 +34,7 @@ export class UserAddressDto {
   @ApiProperty({
     description: 'City',
     example: 'New York',
+    type: String,
   })
   @IsString()
   @IsNotEmpty()
@@ -42,6 +43,7 @@ export class UserAddressDto {
   @ApiProperty({
     description: 'State',
     example: 'NY',
+    type: String,
   })
   @IsString()
   @IsNotEmpty()
@@ -50,20 +52,46 @@ export class UserAddressDto {
   @ApiProperty({
     description: 'ZIP/Postal code',
     example: '10001',
+    type: String,
   })
   @IsString()
   @IsNotEmpty()
   zip: string;
 }
 
-export class CreateAddressDto extends PickType(Address, [
-  'title',
-  'type',
-  'default',
-] as const) {
+export class CreateAddressDto {
+  @ApiProperty({
+    description: 'Address title',
+    example: 'Home',
+    type: String,
+  })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({
+    description: 'Address type',
+    enum: AddressType,
+    example: AddressType.SHIPPING,
+  })
+  @IsEnum(AddressType)
+  @IsNotEmpty()
+  type: AddressType;
+
+  @ApiProperty({
+    description: 'Set as default address',
+    example: false,
+    type: Boolean,
+    default: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  default?: boolean = false;
+
   @ApiProperty({
     description: 'Customer ID to associate address with',
     example: 1,
+    type: Number,
     required: true,
   })
   @IsNumber()

--- a/api/rest/src/addresses/dto/get-addresses.dto.ts
+++ b/api/rest/src/addresses/dto/get-addresses.dto.ts
@@ -1,41 +1,43 @@
-// addresses/dto/get-addresses.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
+import { IsOptional, IsNumber, IsString, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SortOrder } from 'src/common/enums/enums';
 import { Address } from '../entities/address.entity';
+import { AddressOrderByColumn, AddressType } from 'src/common/enums/address-type.enum';
 
-// Add AddressPaginator export
 export class AddressPaginator {
-  @ApiProperty({ type: [Address] })
+  @ApiProperty({ type: () => [Address], description: 'Array of addresses' })
   data: Address[];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Current page number' })
   current_page: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Items per page' })
   per_page: number;
 
-  @ApiProperty({ example: 100 })
+  @ApiProperty({ example: 100, type: Number, description: 'Total items count' })
   total: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Last page number' })
   last_page: number;
 
-  @ApiProperty({ example: '/address?page=1' })
+  @ApiProperty({ example: '/address?page=1', type: String, description: 'First page URL' })
   first_page_url: string;
 
-  @ApiProperty({ example: '/address?page=10' })
+  @ApiProperty({ example: '/address?page=10', type: String, description: 'Last page URL' })
   last_page_url: string;
 
-  @ApiProperty({ example: '/address?page=2', nullable: true })
+  @ApiProperty({ example: '/address?page=2', nullable: true, type: String, description: 'Next page URL' })
   next_page_url: string | null;
 
-  @ApiProperty({ example: '/address?page=1', nullable: true })
+  @ApiProperty({ example: '/address?page=1', nullable: true, type: String, description: 'Previous page URL' })
   prev_page_url: string | null;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Starting item index' })
   from: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Ending item index' })
   to: number;
 }
 
@@ -44,35 +46,49 @@ export class GetAddressesDto extends PaginationArgs {
     description: 'Filter by customer ID',
     required: false,
     example: 1,
+    type: Number,
   })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   customer_id?: number;
 
   @ApiProperty({
     description: 'Filter by address type',
-    enum: ['billing', 'shipping'],
+    enum: AddressType,
     required: false,
   })
-  type?: string;
+  @IsOptional()
+  @IsEnum(AddressType)
+  type?: AddressType;
 
   @ApiProperty({
     description: 'Search text',
     required: false,
+    type: String,
+    example: 'Home',
   })
+  @IsOptional()
+  @IsString()
   text?: string;
 
   @ApiProperty({
-    description: 'Order by field',
-    enum: ['created_at', 'updated_at', 'title'],
+    description: 'Column to order by',
+    enum: AddressOrderByColumn,
     required: false,
-    default: 'created_at',
+    default: AddressOrderByColumn.CREATED_AT,
   })
-  orderBy?: string;
+  @IsOptional()
+  @IsEnum(AddressOrderByColumn)
+  orderBy?: AddressOrderByColumn = AddressOrderByColumn.CREATED_AT;
 
   @ApiProperty({
     description: 'Sort order',
-    enum: ['ASC', 'DESC'],
+    enum: SortOrder,
     required: false,
-    default: 'DESC',
+    default: SortOrder.DESC,
   })
-  sortedBy?: string;
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortedBy?: SortOrder = SortOrder.DESC;
 }

--- a/api/rest/src/addresses/dto/update-address.dto.ts
+++ b/api/rest/src/addresses/dto/update-address.dto.ts
@@ -1,4 +1,3 @@
-// addresses/dto/update-address.dto.ts
 import { PartialType } from '@nestjs/swagger';
 import { CreateAddressDto } from './create-address.dto';
 

--- a/api/rest/src/addresses/entities/address.entity.ts
+++ b/api/rest/src/addresses/entities/address.entity.ts
@@ -1,48 +1,50 @@
-// addresses/entities/address.entity.ts
 import {
   Entity,
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   ManyToOne,
   JoinColumn,
 } from 'typeorm';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { CoreEntity } from 'src/common/entities/core.entity';
 import { User } from 'src/users/entities/user.entity';
-import { AddressType } from '../../common/enums/enums';
+import { AddressType } from 'src/common/enums/address-type.enum';
 
 export class UserAddress {
-  @ApiProperty({ description: 'Street address', example: '123 Main St' })
+  @ApiProperty({ description: 'Street address', example: '123 Main St', type: String })
   street_address: string;
 
-  @ApiProperty({ description: 'Country', example: 'United States' })
+  @ApiProperty({ description: 'Country', example: 'United States', type: String })
   country: string;
 
-  @ApiProperty({ description: 'City', example: 'New York' })
+  @ApiProperty({ description: 'City', example: 'New York', type: String })
   city: string;
 
-  @ApiProperty({ description: 'State', example: 'NY' })
+  @ApiProperty({ description: 'State', example: 'NY', type: String })
   state: string;
 
-  @ApiProperty({ description: 'ZIP/Postal code', example: '10001' })
+  @ApiProperty({ description: 'ZIP/Postal code', example: '10001', type: String })
   zip: string;
 }
 
 @Entity('addresses')
 export class Address extends CoreEntity {
-  @ApiProperty({ description: 'Address ID', example: 1 })
+  @ApiProperty({ description: 'Address ID', example: 1, type: Number })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ApiProperty({ description: 'Address title', example: 'Home' })
+  @ApiProperty({ description: 'Address title', example: 'Home', type: String })
   @Column()
   title: string;
 
   @ApiProperty({
     description: 'Whether this is default address',
     example: false,
+    type: Boolean,
+    default: false,
   })
   @Column({ default: false })
   default: boolean;
@@ -66,23 +68,27 @@ export class Address extends CoreEntity {
     enum: AddressType,
     example: AddressType.SHIPPING,
   })
-  @Column({ type: 'enum', enum: AddressType })
+  @Column({ type: 'varchar', length: 50 })
   type: AddressType;
 
-  @ApiProperty({ type: () => User, description: 'Associated customer' })
+  @ApiHideProperty()
   @ManyToOne(() => User, (user) => user.address, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'customer_id' })
   customer: User;
 
-  @ApiProperty({ description: 'Customer ID', example: 1 })
+  @ApiProperty({ description: 'Customer ID', example: 1, type: Number })
   @Column()
   customer_id: number;
 
-  @ApiProperty({ description: 'Creation timestamp' })
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
+
+  @ApiProperty({ description: 'Creation timestamp', type: Date })
   @CreateDateColumn()
   created_at: Date;
 
-  @ApiProperty({ description: 'Last update timestamp' })
+  @ApiProperty({ description: 'Last update timestamp', type: Date })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/api/rest/src/common/enums/address-type.enum.ts
+++ b/api/rest/src/common/enums/address-type.enum.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum AddressType {
+  BILLING = 'billing',
+  SHIPPING = 'shipping',
+}
+
+export enum AddressOrderByColumn {
+  CREATED_AT = 'created_at',
+  UPDATED_AT = 'updated_at',
+  TITLE = 'title',
+}


### PR DESCRIPTION
Major refactor for addresses feature:

- Controller: renamed handlers (create/findAll/findMyAddresses/findOne/update/remove/setDefault), replaced UnauthorizedException checks with ForbiddenException, added ApiForbiddenResponse and examples, improved Swagger type references.
- Service: introduced softDelete for removals, improved ordering by introducing AddressOrderByColumn/SortOrder enums and mapping to actual columns, cleaned up pagination return and default handling.
- DTOs: replaced PickType-based CreateAddressDto with explicit fields and validations, enhanced GetAddressesDto with enums/types/validation for ordering, sorting and filters, improved response paginator metadata.
- Entity: added DeleteDateColumn (soft deletes), adjusted type column, hid customer relation from Swagger, annotated properties with proper ApiProperty metadata.
- Added new enums file (address-type.enum.ts) defining AddressType and AddressOrderByColumn.

These changes improve type-safety, API documentation, permission handling, and enable soft deletes and flexible sorting.