### PR TITLE
Refactor: Enhance flash-sale DTOs, service and Swagger

### DIFF
--- a/api/rest/src/common/enums/flash-sale.enum.ts
+++ b/api/rest/src/common/enums/flash-sale.enum.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum FlashSaleType {
+  PERCENTAGE = 'percentage',
+  FIXED_RATE = 'fixed_rate',
+}
+
+export enum FlashSaleOrderByColumn {
+  CREATED_AT = 'created_at',
+  UPDATED_AT = 'updated_at',
+  TITLE = 'title',
+  START_DATE = 'start_date',
+  END_DATE = 'end_date',
+}

--- a/api/rest/src/flash-sale/dto/create-flash-sale.dto.ts
+++ b/api/rest/src/flash-sale/dto/create-flash-sale.dto.ts
@@ -1,5 +1,4 @@
-// flash-sale/dto/create-flash-sale.dto.ts
-import { ApiProperty, PickType } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
   IsString,
   IsOptional,
@@ -8,15 +7,47 @@ import {
   IsObject,
   IsArray,
   ValidateNested,
+  IsEnum,
+  IsDate,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { FlashSale } from '../entities/flash-sale.entity';
-import { Attachment } from '../../common/entities/attachment.entity';
+import { FlashSaleType } from 'src/common/enums/flash-sale.enum';
+
+class AttachmentDto {
+  @ApiProperty({ required: false, type: Number, example: 0 })
+  @IsNumber()
+  @IsOptional()
+  id?: number;
+
+  @ApiProperty({ required: false, type: String, example: '2026-05-10T15:40:55.818Z' })
+  @Type(() => Date)
+  @IsDate()
+  @IsOptional()
+  created_at?: Date;
+
+  @ApiProperty({ required: false, type: String, example: '2026-05-10T15:40:55.818Z' })
+  @Type(() => Date)
+  @IsDate()
+  @IsOptional()
+  updated_at?: Date;
+
+  @ApiProperty({ required: false, type: String, example: 'string' })
+  @IsString()
+  @IsOptional()
+  thumbnail?: string;
+
+  @ApiProperty({ required: false, type: String, example: 'string' })
+  @IsString()
+  @IsOptional()
+  original?: string;
+}
+
 
 export class CreateFlashSaleDto {
   @ApiProperty({
     description: 'Flash sale title',
     example: 'Limited-Time Offer: Act Fast!',
+    type: String,
   })
   @IsString()
   title: string;
@@ -24,58 +55,89 @@ export class CreateFlashSaleDto {
   @ApiProperty({
     description: 'Flash sale description',
     example: "Don't miss out on our incredible...",
+    type: String,
   })
   @IsString()
   description: string;
 
-  @ApiProperty({ description: 'Start date', example: '2023-10-31 06:49:59' })
+  @ApiProperty({ 
+    description: 'Start date', 
+    example: '2023-10-31 06:49:59',
+    type: String,
+  })
   @IsString()
   start_date: string;
 
-  @ApiProperty({ description: 'End date', example: '2024-11-29 18:00:00' })
+  @ApiProperty({ 
+    description: 'End date', 
+    example: '2024-11-29 18:00:00',
+    type: String,
+  })
   @IsString()
   end_date: string;
 
-  @ApiProperty({ description: 'Flash sale type', example: 'percentage' })
-  @IsString()
-  type: string;
+  @ApiProperty({ 
+    description: 'Flash sale type', 
+    enum: FlashSaleType,
+    example: FlashSaleType.PERCENTAGE,
+  })
+  @IsEnum(FlashSaleType)
+  type: FlashSaleType;
 
-  @ApiProperty({ description: 'Discount rate', example: '50' })
+  @ApiProperty({ 
+    description: 'Discount rate', 
+    example: '50',
+    type: String,
+  })
   @IsString()
   rate: string;
 
   @ApiProperty({
-    type: Attachment,
+    type: AttachmentDto,
     description: 'Flash sale image',
     required: false,
   })
   @ValidateNested()
-  @Type(() => Attachment)
+  @Type(() => AttachmentDto)
   @IsOptional()
-  image?: Attachment;
+  image?: AttachmentDto;
 
   @ApiProperty({
-    type: Attachment,
+    type: AttachmentDto,
     description: 'Cover image',
     required: false,
   })
   @ValidateNested()
-  @Type(() => Attachment)
+  @Type(() => AttachmentDto)
   @IsOptional()
-  cover_image?: Attachment;
+  cover_image?: AttachmentDto;
 
-  @ApiProperty({ description: 'Sale builder configuration', required: false })
+  @ApiProperty({ 
+    description: 'Sale builder configuration', 
+    required: false,
+    type: Object,
+  })
   @IsObject()
   @IsOptional()
   sale_builder?: any;
 
-  @ApiProperty({ description: 'Product IDs', type: [Number], required: false })
+  @ApiProperty({ 
+    description: 'Product IDs', 
+    type: [Number], 
+    required: false,
+    example: [951, 952],
+  })
   @IsArray()
   @IsOptional()
   product_ids?: number[];
 
-  @ApiProperty({ description: 'Language code', default: 'en' })
+  @ApiProperty({ 
+    description: 'Language code', 
+    default: 'en',
+    type: String,
+    example: 'en',
+  })
   @IsString()
   @IsOptional()
-  language?: string;
+  language?: string = 'en';
 }

--- a/api/rest/src/flash-sale/dto/flash-sale-response.dto.ts
+++ b/api/rest/src/flash-sale/dto/flash-sale-response.dto.ts
@@ -1,14 +1,13 @@
-// flash-sale/dto/flash-sale-response.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { FlashSale } from '../entities/flash-sale.entity';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 
 export class FlashSaleResponse {
-  @ApiProperty({ type: FlashSale })
+  @ApiProperty({ type: () => FlashSale, description: 'Flash sale data' })
   flashSale: FlashSale;
 }
 
 export class FlashSaleMutationResponse extends CoreMutationOutput {
-  @ApiProperty({ type: FlashSale, required: false })
+  @ApiProperty({ type: () => FlashSale, required: false, description: 'Updated flash sale data' })
   flashSale?: FlashSale;
 }

--- a/api/rest/src/flash-sale/dto/get-flash-sales.dto.ts
+++ b/api/rest/src/flash-sale/dto/get-flash-sales.dto.ts
@@ -1,61 +1,106 @@
-// flash-sale/dto/get-flash-sales.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
 import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
+import { IsOptional, IsString, IsBoolean, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
 import { FlashSale } from '../entities/flash-sale.entity';
-import { QueryFlashSaleOrderByColumn } from '../../common/enums/enums';
+import { FlashSaleOrderByColumn, FlashSaleType } from 'src/common/enums/flash-sale.enum';
+import { SortOrder } from 'src/common/enums/enums';
 
 export class FlashSalePaginator {
-  @ApiProperty({ type: [FlashSale] })
+  @ApiProperty({ type: () => [FlashSale], description: 'Array of flash sales' })
   data: FlashSale[];
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Current page number' })
   current_page: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number, description: 'Items per page' })
   per_page: number;
 
-  @ApiProperty({ example: 100 })
+  @ApiProperty({ example: 100, type: Number, description: 'Total items count' })
   total: number;
 
-  @ApiProperty({ example: 10 })
+  @ApiProperty({ example: 10, type: Number, description: 'Last page number' })
   last_page: number;
 
-  @ApiProperty({ example: '/flash-sale?page=1' })
+  @ApiProperty({ example: '/flash-sale?page=1', type: String, description: 'First page URL' })
   first_page_url: string;
 
-  @ApiProperty({ example: '/flash-sale?page=10' })
+  @ApiProperty({ example: '/flash-sale?page=10', type: String, description: 'Last page URL' })
   last_page_url: string;
 
-  @ApiProperty({ example: '/flash-sale?page=2', nullable: true })
+  @ApiProperty({ example: '/flash-sale?page=2', nullable: true, type: String, description: 'Next page URL' })
   next_page_url: string | null;
 
-  @ApiProperty({ example: '/flash-sale?page=1', nullable: true })
+  @ApiProperty({ example: '/flash-sale?page=1', nullable: true, type: String, description: 'Previous page URL' })
   prev_page_url: string | null;
 
-  @ApiProperty({ example: 1 })
+  @ApiProperty({ example: 1, type: Number, description: 'Starting item index' })
   from: number;
 
-  @ApiProperty({ example: 30 })
+  @ApiProperty({ example: 30, type: Number, description: 'Ending item index' })
   to: number;
 }
 
 export class GetFlashSaleDto extends PaginationArgs {
-  @ApiProperty({ enum: QueryFlashSaleOrderByColumn, required: false })
-  orderBy?: QueryFlashSaleOrderByColumn;
+  @ApiProperty({ 
+    enum: FlashSaleOrderByColumn, 
+    required: false, 
+    default: FlashSaleOrderByColumn.CREATED_AT,
+    description: 'Column to order by',
+  })
+  @IsOptional()
+  @IsEnum(FlashSaleOrderByColumn)
+  orderBy?: FlashSaleOrderByColumn = FlashSaleOrderByColumn.CREATED_AT;
 
-  @ApiProperty({ enum: SortOrder, required: false, default: SortOrder.DESC })
-  sortedBy?: SortOrder;
+  @ApiProperty({ 
+    enum: SortOrder, 
+    required: false, 
+    default: SortOrder.DESC,
+    description: 'Sort direction',
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortedBy?: SortOrder = SortOrder.DESC;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ 
+    required: false, 
+    type: String,
+    description: 'Search term',
+    example: 'Limited-Time',
+  })
+  @IsOptional()
+  @IsString()
   search?: string;
 
-  @ApiProperty({ required: false, default: 'en' })
-  language?: string;
+  @ApiProperty({ 
+    required: false, 
+    default: 'en',
+    type: String,
+    description: 'Language code',
+    example: 'en',
+  })
+  @IsOptional()
+  @IsString()
+  language?: string = 'en';
 
-  @ApiProperty({ required: false })
-  type?: string;
+  @ApiProperty({ 
+    required: false, 
+    enum: FlashSaleType,
+    description: 'Filter by flash sale type',
+    example: FlashSaleType.PERCENTAGE,
+  })
+  @IsOptional()
+  @IsEnum(FlashSaleType)
+  type?: FlashSaleType;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ 
+    required: false, 
+    type: Boolean,
+    description: 'Filter by sale status',
+    example: true,
+  })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
   sale_status?: boolean;
 }

--- a/api/rest/src/flash-sale/dto/update-flash-sale.dto.ts
+++ b/api/rest/src/flash-sale/dto/update-flash-sale.dto.ts
@@ -1,4 +1,3 @@
-// flash-sale/dto/update-flash-sale.dto.ts
 import { PartialType } from '@nestjs/swagger';
 import { CreateFlashSaleDto } from './create-flash-sale.dto';
 

--- a/api/rest/src/flash-sale/entities/flash-sale.entity.ts
+++ b/api/rest/src/flash-sale/entities/flash-sale.entity.ts
@@ -1,4 +1,3 @@
-// flash-sale/entities/flash-sale.entity.ts
 import {
   Entity,
   Column,
@@ -7,22 +6,20 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
 } from 'typeorm';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { CoreEntity } from '../../common/entities/core.entity';
 import { Attachment } from '../../common/entities/attachment.entity';
-
-// Comment out Product import for now
-// import { Product } from '../../products/entities/product.entity';
-
+import { FlashSaleType } from 'src/common/enums/flash-sale.enum';
 @Entity('flash_sales')
 export class FlashSale extends CoreEntity {
-  @ApiProperty({ description: 'Flash sale ID', example: 1 })
+  @ApiProperty({ description: 'Flash sale ID', example: 1, type: Number })
   @PrimaryGeneratedColumn()
   id: number;
 
   @ApiProperty({
     description: 'Flash sale title',
     example: 'Limited-Time Offer: Act Fast!',
+    type: String,
   })
   @Column()
   title: string;
@@ -30,6 +27,7 @@ export class FlashSale extends CoreEntity {
   @ApiProperty({
     description: 'Flash sale slug',
     example: 'limited-time-offer-act-fast',
+    type: String,
   })
   @Column({ unique: true })
   slug: string;
@@ -37,15 +35,24 @@ export class FlashSale extends CoreEntity {
   @ApiProperty({
     description: 'Flash sale description',
     example: "Don't miss out on our incredible...",
+    type: String,
   })
   @Column('text')
   description: string;
 
-  @ApiProperty({ description: 'Start date', example: '2023-10-31 06:49:59' })
+  @ApiProperty({ 
+    description: 'Start date', 
+    example: '2023-10-31 06:49:59',
+    type: String,
+  })
   @Column()
   start_date: string;
 
-  @ApiProperty({ description: 'End date', example: '2024-11-29 18:00:00' })
+  @ApiProperty({ 
+    description: 'End date', 
+    example: '2024-11-29 18:00:00',
+    type: String,
+  })
   @Column()
   end_date: string;
 
@@ -65,49 +72,75 @@ export class FlashSale extends CoreEntity {
   @Column('json', { nullable: true })
   cover_image?: Attachment;
 
-  @ApiProperty({ description: 'Flash sale type', example: 'percentage' })
+  @ApiProperty({ 
+    description: 'Flash sale type', 
+    enum: FlashSaleType,
+    example: FlashSaleType.PERCENTAGE,
+    type: String,
+  })
   @Column()
   type: string;
 
-  @ApiProperty({ description: 'Discount rate', example: '50' })
+  @ApiProperty({ 
+    description: 'Discount rate', 
+    example: '50',
+    type: String,
+  })
   @Column()
   rate: string;
 
-  @ApiProperty({ description: 'Sale status', example: true })
+  @ApiProperty({ 
+    description: 'Sale status', 
+    example: true,
+    type: Boolean,
+    default: true,
+  })
   @Column({ default: true })
   sale_status: boolean;
 
-  @ApiProperty({ description: 'Sale builder configuration', required: false })
+  @ApiProperty({ 
+    description: 'Sale builder configuration', 
+    required: false,
+    type: Object,
+  })
   @Column('json', { nullable: true })
   sale_builder?: any;
 
-  @ApiProperty({ description: 'Language code', default: 'en' })
+  @ApiProperty({ 
+    description: 'Language code', 
+    default: 'en',
+    type: String,
+    example: 'en',
+  })
   @Column({ default: 'en' })
   language: string;
 
-  @ApiProperty({ description: 'Translated languages', type: [String] })
+  @ApiProperty({ 
+    description: 'Translated languages', 
+    type: [String],
+    example: ['en', 'es', 'fr'],
+  })
   @Column('simple-array', { nullable: true })
   translated_languages: string[];
 
-  // Comment out products relation for now
-  // @ApiProperty({ type: () => [Product], description: 'Products in flash sale' })
-  // @ManyToMany(() => Product)
-  // @JoinTable()
-  // products: Product[];
-
-  @ApiProperty({ description: 'Product IDs', type: [Number], required: false })
+  @ApiProperty({ 
+    description: 'Product IDs', 
+    type: [Number],
+    required: false,
+    example: [951, 952],
+  })
   @Column('simple-array', { nullable: true })
   product_ids?: number[];
 
-  @ApiProperty({ description: 'Soft delete timestamp', required: false })
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
   @DeleteDateColumn()
   deleted_at?: Date;
 
-  @ApiProperty({ description: 'Creation timestamp' })
+  @ApiProperty({ description: 'Creation timestamp', type: Date })
   @CreateDateColumn()
   created_at: Date;
 
-  @ApiProperty({ description: 'Last update timestamp' })
+  @ApiProperty({ description: 'Last update timestamp', type: Date })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/api/rest/src/flash-sale/flash-sale.controller.ts
+++ b/api/rest/src/flash-sale/flash-sale.controller.ts
@@ -1,4 +1,3 @@
-// flash-sale/flash-sale.controller.ts
 import {
   Body,
   Controller,
@@ -14,7 +13,6 @@ import {
 import {
   ApiTags,
   ApiOperation,
-  ApiResponse,
   ApiBearerAuth,
   ApiBody,
   ApiParam,
@@ -35,7 +33,7 @@ import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { Roles } from '../common/decorators/roles.decorator';
-import { Permission } from '../common/enums/enums';
+import { Permission, SortOrder } from '../common/enums/enums';
 import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('⚡ Flash Sales')
@@ -53,15 +51,13 @@ export class FlashSaleController {
   })
   @ApiCreatedResponse({
     description: 'Flash sale created successfully',
-    type: FlashSale,
+    type: () => FlashSale,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @ApiBody({ type: CreateFlashSaleDto })
-  createFlashSale(
-    @Body() createFlashSaleDto: CreateFlashSaleDto,
-  ): Promise<FlashSale> {
+  create(@Body() createFlashSaleDto: CreateFlashSaleDto): Promise<FlashSale> {
     return this.flashSaleService.create(createFlashSaleDto);
   }
 
@@ -75,14 +71,11 @@ export class FlashSaleController {
     description: 'Flash sales retrieved successfully',
     type: FlashSalePaginator,
   })
-  @ApiQuery({ name: 'search', required: false })
-  @ApiQuery({ name: 'type', required: false })
-  @ApiQuery({ name: 'sale_status', required: false })
   findAll(@Query() query: GetFlashSaleDto): Promise<FlashSalePaginator> {
-    return this.flashSaleService.findAllFlashSale(query);
+    return this.flashSaleService.findAll(query);
   }
 
-  @Get(':param')
+  @Get(':param((?!products$)[^/]+)')
   @Public()
   @ApiOperation({
     summary: 'Get flash sale by ID or slug',
@@ -92,18 +85,18 @@ export class FlashSaleController {
     name: 'param',
     description: 'Flash sale ID or slug',
     example: '1 or limited-time-offer-act-fast',
+    type: String,
   })
   @ApiOkResponse({
     description: 'Flash sale retrieved successfully',
-    type: FlashSale,
+    type: () => FlashSale,
   })
   @ApiNotFoundResponse({ description: 'Flash sale not found' })
-  @ApiQuery({ name: 'language', required: false })
-  getFlashSale(
+  findOne(
     @Param('param') param: string,
-    @Query('language') language: string,
+    @Query('language') language?: string,
   ): Promise<FlashSale> {
-    return this.flashSaleService.getFlashSale(param, language);
+    return this.flashSaleService.findOne(param, language);
   }
 
   @Put(':id')
@@ -112,10 +105,10 @@ export class FlashSaleController {
     summary: 'Update flash sale',
     description: 'Update flash sale information by ID (Admin only)',
   })
-  @ApiParam({ name: 'id', description: 'Flash sale ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Flash sale ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Flash sale updated successfully',
-    type: FlashSale,
+    type: () => FlashSale,
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiNotFoundResponse({ description: 'Flash sale not found' })
@@ -131,28 +124,26 @@ export class FlashSaleController {
   @Roles(Permission.SUPER_ADMIN)
   @ApiOperation({
     summary: 'Delete flash sale',
-    description: 'Permanently delete a flash sale by ID (Admin only)',
+    description: 'Soft delete a flash sale by ID (Admin only)',
   })
-  @ApiParam({ name: 'id', description: 'Flash sale ID', type: Number })
+  @ApiParam({ name: 'id', description: 'Flash sale ID', type: Number, example: 1 })
   @ApiOkResponse({
     description: 'Flash sale deleted successfully',
     type: CoreMutationOutput,
   })
   @ApiNotFoundResponse({ description: 'Flash sale not found' })
-  deleteFlashSale(
-    @Param('id', ParseIntPipe) id: number,
-  ): Promise<CoreMutationOutput> {
+  remove(@Param('id', ParseIntPipe) id: number): Promise<CoreMutationOutput> {
     return this.flashSaleService.remove(id);
   }
 }
 
-@ApiTags('⚡ Flash Sales - Products')
-@Controller('products-by-flash-sale')
+@ApiTags('⚡ Flash Sales')
+@Controller('flash-sale')
 @Public()
 export class ProductsByFlashSaleController {
   constructor(private flashSaleService: FlashSaleService) {}
 
-  @Get()
+  @Get('products')
   @ApiOperation({
     summary: 'Get products by flash sale',
     description: 'Retrieve paginated list of products by flash sale (Public)',
@@ -163,23 +154,42 @@ export class ProductsByFlashSaleController {
       type: 'object',
       properties: {
         data: { type: 'array', items: { type: 'object' } },
-        current_page: { type: 'number' },
-        per_page: { type: 'number' },
-        total: { type: 'number' },
-        last_page: { type: 'number' },
+        current_page: { type: 'number', example: 1 },
+        per_page: { type: 'number', example: 15 },
+        total: { type: 'number', example: 100 },
+        last_page: { type: 'number', example: 10 },
       },
     },
   })
-  findAll(@Query() query: GetFlashSaleDto): Promise<any> {
+  findAllProducts(@Query() query: GetFlashSaleDto): Promise<any> {
     return this.flashSaleService.findAllProductsByFlashSale(query);
   }
 
-  @Get(':flashSaleId')
+  @Get(':flashSaleId/products')
   @ApiOperation({
     summary: 'Get products by flash sale ID',
     description: 'Retrieve products for a specific flash sale',
   })
-  @ApiParam({ name: 'flashSaleId', description: 'Flash sale ID', type: Number })
+  @ApiParam({ 
+    name: 'flashSaleId', 
+    description: 'Flash sale ID', 
+    type: Number,
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Products retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        data: { type: 'array', items: { type: 'object' } },
+        flashSale: { type: 'object' },
+        current_page: { type: 'number' },
+        per_page: { type: 'number' },
+        total: { type: 'number' },
+      },
+    },
+  })
+  @ApiNotFoundResponse({ description: 'Flash sale not found' })
   getProductsByFlashSaleId(
     @Param('flashSaleId', ParseIntPipe) flashSaleId: number,
     @Query() query: GetFlashSaleDto,

--- a/api/rest/src/flash-sale/flash-sale.module.ts
+++ b/api/rest/src/flash-sale/flash-sale.module.ts
@@ -1,4 +1,3 @@
-// flash-sale/flash-sale.module.ts
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import {

--- a/api/rest/src/flash-sale/flash-sale.service.ts
+++ b/api/rest/src/flash-sale/flash-sale.service.ts
@@ -1,13 +1,12 @@
-// flash-sale/flash-sale.service.ts
 import {
   Injectable,
   NotFoundException,
   ConflictException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThan, MoreThan, Between } from 'typeorm';
-import { plainToClass } from 'class-transformer';
+import { Repository, LessThan, MoreThan } from 'typeorm';
 import { FlashSale } from './entities/flash-sale.entity';
+import { Attachment } from 'src/common/entities/attachment.entity';
 import {
   GetFlashSaleDto,
   FlashSalePaginator,
@@ -16,8 +15,8 @@ import { CreateFlashSaleDto } from './dto/create-flash-sale.dto';
 import { UpdateFlashSaleDto } from './dto/update-flash-sale.dto';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { paginate } from 'src/common/pagination/paginate';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
-import { QueryFlashSaleOrderByColumn } from '../common/enums/enums';
+import { SortOrder } from 'src/common/enums/enums';
+import { FlashSaleOrderByColumn } from 'src/common/enums/flash-sale.enum';
 
 @Injectable()
 export class FlashSaleService {
@@ -27,10 +26,8 @@ export class FlashSaleService {
   ) {}
 
   async create(createFlashSaleDto: CreateFlashSaleDto): Promise<FlashSale> {
-    // Generate slug from title
     const slug = this.generateSlug(createFlashSaleDto.title);
 
-    // Check if flash sale with same slug exists
     const existing = await this.flashSaleRepository.findOne({
       where: { slug },
     });
@@ -47,8 +44,8 @@ export class FlashSaleService {
       end_date: createFlashSaleDto.end_date,
       type: createFlashSaleDto.type,
       rate: createFlashSaleDto.rate,
-      image: createFlashSaleDto.image,
-      cover_image: createFlashSaleDto.cover_image,
+      image: (createFlashSaleDto.image as unknown) as Attachment,
+      cover_image: (createFlashSaleDto.cover_image as unknown) as Attachment,
       sale_builder: createFlashSaleDto.sale_builder,
       product_ids: createFlashSaleDto.product_ids,
       language: createFlashSaleDto.language || 'en',
@@ -60,27 +57,24 @@ export class FlashSaleService {
     return this.flashSaleRepository.save(flashSale);
   }
 
-  async findAllFlashSale({
+  async findAll({
     page = 1,
     limit = 10,
     search,
     type,
     sale_status,
     language,
-    orderBy = QueryFlashSaleOrderByColumn.CREATED_AT,
+    orderBy = FlashSaleOrderByColumn.CREATED_AT,
     sortedBy = SortOrder.DESC,
   }: GetFlashSaleDto): Promise<FlashSalePaginator> {
-    const queryBuilder =
-      this.flashSaleRepository.createQueryBuilder('flashSale');
+    const queryBuilder = this.flashSaleRepository.createQueryBuilder('flashSale');
 
     if (type) {
       queryBuilder.andWhere('flashSale.type = :type', { type });
     }
 
     if (sale_status !== undefined) {
-      queryBuilder.andWhere('flashSale.sale_status = :sale_status', {
-        sale_status,
-      });
+      queryBuilder.andWhere('flashSale.sale_status = :sale_status', { sale_status });
     }
 
     if (search) {
@@ -97,21 +91,26 @@ export class FlashSaleService {
       );
     }
 
-    // Apply ordering
-    const orderColumn =
-      orderBy === QueryFlashSaleOrderByColumn.TITLE
-        ? 'flashSale.title'
-        : orderBy === QueryFlashSaleOrderByColumn.START_DATE
-        ? 'flashSale.start_date'
-        : orderBy === QueryFlashSaleOrderByColumn.END_DATE
-        ? 'flashSale.end_date'
-        : orderBy === QueryFlashSaleOrderByColumn.UPDATED_AT
-        ? 'flashSale.updated_at'
-        : 'flashSale.created_at';
+    let orderColumn: string;
+    switch (orderBy) {
+      case FlashSaleOrderByColumn.TITLE:
+        orderColumn = 'flashSale.title';
+        break;
+      case FlashSaleOrderByColumn.START_DATE:
+        orderColumn = 'flashSale.start_date';
+        break;
+      case FlashSaleOrderByColumn.END_DATE:
+        orderColumn = 'flashSale.end_date';
+        break;
+      case FlashSaleOrderByColumn.UPDATED_AT:
+        orderColumn = 'flashSale.updated_at';
+        break;
+      default:
+        orderColumn = 'flashSale.created_at';
+    }
 
     const orderDirection = sortedBy === SortOrder.ASC ? 'ASC' : 'DESC';
     queryBuilder.orderBy(orderColumn, orderDirection);
-
     queryBuilder.skip((page - 1) * limit).take(limit);
 
     const [data, total] = await queryBuilder.getManyAndCount();
@@ -131,7 +130,7 @@ export class FlashSaleService {
     };
   }
 
-  async getFlashSale(param: string, language?: string): Promise<FlashSale> {
+  async findOne(param: string, language?: string): Promise<FlashSale> {
     const isId = !isNaN(Number(param));
 
     const queryBuilder = this.flashSaleRepository
@@ -159,10 +158,7 @@ export class FlashSaleService {
     return flashSale;
   }
 
-  async update(
-    id: number,
-    updateFlashSaleDto: UpdateFlashSaleDto,
-  ): Promise<FlashSale> {
+  async update(id: number, updateFlashSaleDto: UpdateFlashSaleDto): Promise<FlashSale> {
     const flashSale = await this.flashSaleRepository.findOne({
       where: { id },
     });
@@ -171,7 +167,6 @@ export class FlashSaleService {
       throw new NotFoundException(`Flash sale with ID ${id} not found`);
     }
 
-    // Update fields
     if (updateFlashSaleDto.title) {
       flashSale.title = updateFlashSaleDto.title;
       flashSale.slug = this.generateSlug(updateFlashSaleDto.title);
@@ -198,11 +193,11 @@ export class FlashSaleService {
     }
 
     if (updateFlashSaleDto.image !== undefined) {
-      flashSale.image = updateFlashSaleDto.image;
+      flashSale.image = updateFlashSaleDto.image as unknown as Attachment;
     }
 
     if (updateFlashSaleDto.cover_image !== undefined) {
-      flashSale.cover_image = updateFlashSaleDto.cover_image;
+      flashSale.cover_image = updateFlashSaleDto.cover_image as unknown as Attachment;
     }
 
     if (updateFlashSaleDto.sale_builder !== undefined) {
@@ -215,9 +210,7 @@ export class FlashSaleService {
 
     if (updateFlashSaleDto.language) {
       flashSale.language = updateFlashSaleDto.language;
-      if (
-        !flashSale.translated_languages.includes(updateFlashSaleDto.language)
-      ) {
+      if (!flashSale.translated_languages.includes(updateFlashSaleDto.language)) {
         flashSale.translated_languages = [
           ...flashSale.translated_languages,
           updateFlashSaleDto.language,
@@ -237,7 +230,6 @@ export class FlashSaleService {
       throw new NotFoundException(`Flash sale with ID ${id} not found`);
     }
 
-    // Soft delete
     await this.flashSaleRepository.softDelete(id);
 
     return {
@@ -251,22 +243,12 @@ export class FlashSaleService {
     limit,
     page,
   }: GetFlashSaleDto): Promise<any> {
-    // This is a placeholder until Product module is available
-    // In a real implementation, you would query products that are in flash sales
-
-    // For now, return empty paginated response
     return {
       data: [],
       current_page: page || 1,
       per_page: limit || 10,
       total: 0,
       last_page: 0,
-      first_page_url: `/products-by-flash-sale?page=1&limit=${limit || 10}`,
-      last_page_url: `/products-by-flash-sale?page=0&limit=${limit || 10}`,
-      next_page_url: null,
-      prev_page_url: null,
-      from: 0,
-      to: 0,
     };
   }
 
@@ -279,13 +261,8 @@ export class FlashSaleService {
     });
 
     if (!flashSale) {
-      throw new NotFoundException(
-        `Flash sale with ID ${flashSaleId} not found`,
-      );
+      throw new NotFoundException(`Flash sale with ID ${flashSaleId} not found`);
     }
-
-    // This is a placeholder until Product module is available
-    // In a real implementation, you would query products by product_ids
 
     return {
       data: [],

--- a/api/rest/src/main.ts
+++ b/api/rest/src/main.ts
@@ -31,8 +31,8 @@ async function bootstrap() {
         type: 'http',
         scheme: 'bearer',
         bearerFormat: 'JWT-Access Token',
-        name: 'JWT',
-        description: 'Enter JWT token',
+        name: 'Authorization',
+        description: 'Enter JWT token (Prefix with "Bearer ")',
         in: 'header',
       },
       'JWT-auth',
@@ -42,8 +42,8 @@ async function bootstrap() {
         type: 'http',
         scheme: 'bearer',
         bearerFormat: 'JWT-Refresh Token',
-        name: 'Refresh Token',
-        description: 'Enter refresh token',
+        name: 'Authorization',
+        description: 'Enter refresh token (Prefix with "Bearer ")',
         in: 'header',
       },
       'refresh-token',
@@ -51,6 +51,12 @@ async function bootstrap() {
     .build();
     
   const document = SwaggerModule.createDocument(app, config);
+  // Apply JWT-auth as a global security requirement so Swagger 'Try it out' sends Authorization
+  // This ensures endpoints protected with @ApiBearerAuth('JWT-auth') receive the header
+  document.security = document.security || [];
+  if (!document.security.find((s) => Object.prototype.hasOwnProperty.call(s, 'JWT-auth'))) {
+    document.security.push({ 'JWT-auth': [] });
+  }
   SwaggerModule.setup('docs', app, document);
   
   const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
Add FlashSale enums and tighten DTOs: introduce FlashSaleType/OrderBy enums, AttachmentDto, stronger class-validator decorators, defaults and improved ApiProperty metadata. Update entity to use enums/typed ApiProperty, annotate dates, product IDs and images. Refactor controller and routes: rename methods (create/findAll/findOne/remove), restrict param route, add products endpoints and improve Swagger decorators/responses. Refactor service: rename methods, cast attachment fields, implement robust ordering logic, simplify placeholders, and use new enums. Apply global Swagger security entry for JWT headers to improve 'Try it out' behavior.