### PR TITLE
feat: Migrate messages to TypeORM and update APIs

### DIFF
--- a/api/rest/src/common/enums/message-order-by.enum.ts
+++ b/api/rest/src/common/enums/message-order-by.enum.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum MessageOrderByColumn {
+  CREATED_AT = 'created_at',
+  UPDATED_AT = 'updated_at',
+  ID = 'id',
+}

--- a/api/rest/src/messages/dto/create-message.dto.ts
+++ b/api/rest/src/messages/dto/create-message.dto.ts
@@ -1,15 +1,34 @@
-// messages/dto/create-message.dto.ts
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
-import { Message } from '../entities/message.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsNumber, IsOptional } from 'class-validator';
 
-export class CreateMessageDto extends PickType(Message, ['body']) {
+export class CreateMessageDto {
+  @ApiProperty({
+    description: 'Conversation ID',
+    example: 1,
+    required: true,
+    type: Number,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  conversation_id: number;
+
   @ApiProperty({
     description: 'Message body content',
     example: 'Hello, how can I help you?',
-    required: true
+    required: true,
+    type: String,
   })
   @IsString()
   @IsNotEmpty()
   body: string;
+
+  @ApiProperty({
+    description: 'User ID sending the message',
+    example: 6,
+    required: false,
+    type: Number,
+  })
+  @IsNumber()
+  @IsOptional()
+  user_id?: number;
 }

--- a/api/rest/src/messages/dto/get-messages.dto.ts
+++ b/api/rest/src/messages/dto/get-messages.dto.ts
@@ -1,34 +1,73 @@
-// messages/dto/get-messages.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
-import { Paginator } from 'src/common/dto/paginator.dto';
+import { IsOptional, IsString, IsEnum } from 'class-validator';
+import { SortOrder } from 'src/common/enums/enums';
 import { Message } from '../entities/message.entity';
+import { MessageOrderByColumn } from 'src/common/enums/message-order-by.enum';
 
-export class MessagePaginator extends Paginator<Message> {
-  @ApiProperty({ type: [Message] })
+export class MessagePaginator {
+  @ApiProperty({ type: () => [Message], description: 'Array of messages' })
   data: Message[];
+
+  @ApiProperty({ example: 1, type: Number, description: 'Current page number' })
+  current_page: number;
+
+  @ApiProperty({ example: 30, type: Number, description: 'Items per page' })
+  per_page: number;
+
+  @ApiProperty({ example: 100, type: Number, description: 'Total items count' })
+  total: number;
+
+  @ApiProperty({ example: 10, type: Number, description: 'Last page number' })
+  last_page: number;
+
+  @ApiProperty({ example: '/messages?page=1', type: String, description: 'First page URL' })
+  first_page_url: string;
+
+  @ApiProperty({ example: '/messages?page=10', type: String, description: 'Last page URL' })
+  last_page_url: string;
+
+  @ApiProperty({ example: '/messages?page=2', nullable: true, type: String, description: 'Next page URL' })
+  next_page_url: string | null;
+
+  @ApiProperty({ example: '/messages?page=1', nullable: true, type: String, description: 'Previous page URL' })
+  prev_page_url: string | null;
+
+  @ApiProperty({ example: 1, type: Number, description: 'Starting item index' })
+  from: number;
+
+  @ApiProperty({ example: 30, type: Number, description: 'Ending item index' })
+  to: number;
 }
 
 export class GetMessagesDto extends PaginationArgs {
   @ApiProperty({
     description: 'Search text in messages',
-    required: false
+    required: false,
+    type: String,
+    example: 'hello',
   })
+  @IsOptional()
+  @IsString()
   search?: string;
 
   @ApiProperty({
-    description: 'Order by field',
-    enum: ['created_at', 'updated_at', 'id'],
+    description: 'Order by column',
+    enum: MessageOrderByColumn,
     required: false,
-    default: 'created_at'
+    default: MessageOrderByColumn.CREATED_AT,
   })
-  orderBy?: string;
+  @IsOptional()
+  @IsEnum(MessageOrderByColumn)
+  orderBy?: MessageOrderByColumn = MessageOrderByColumn.CREATED_AT;
 
   @ApiProperty({
     description: 'Sort order',
-    enum: ['ASC', 'DESC'],
+    enum: SortOrder,
     required: false,
-    default: 'DESC'
+    default: SortOrder.DESC,
   })
-  sortedBy?: string;
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortedBy?: SortOrder = SortOrder.DESC;
 }

--- a/api/rest/src/messages/entities/message.entity.ts
+++ b/api/rest/src/messages/entities/message.entity.ts
@@ -1,35 +1,48 @@
-// messages/entities/message.entity.ts
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
-import { ApiProperty } from '@nestjs/swagger';
+import { 
+  Entity, 
+  Column, 
+  PrimaryGeneratedColumn, 
+  CreateDateColumn, 
+  UpdateDateColumn, 
+  DeleteDateColumn,
+  ManyToOne,
+  JoinColumn 
+} from 'typeorm';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { Conversation } from 'src/conversations/entities/conversation.entity';
-
 
 @Entity('messages')
 export class Message {
-  @ApiProperty({ description: 'Message ID', example: 1 })
+  @ApiProperty({ description: 'Message ID', example: 1, type: Number })
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ApiProperty({ description: 'Conversation ID', example: 1 })
+  @ApiProperty({ description: 'Conversation ID', example: 1, type: Number })
   @Column()
   conversation_id: number;
 
-  @ApiProperty({ description: 'User ID who sent the message', example: 6 })
+  @ApiProperty({ description: 'User ID who sent the message', example: 6, type: Number })
   @Column()
   user_id: number;
 
-  @ApiProperty({ description: 'Message body content', example: 'Hello, how can I help you?' })
+  @ApiProperty({ description: 'Message body content', example: 'Hello, how can I help you?', type: String })
   @Column({ type: 'text' })
   body: string;
 
-  @ApiProperty({ description: 'Conversation', type: () => Conversation }) // Commented for future use
+  @ApiHideProperty()
+  @ManyToOne(() => Conversation)
+  @JoinColumn({ name: 'conversation_id' })
   conversation: Conversation;
 
-  @ApiProperty({ description: 'Creation timestamp' })
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
+
+  @ApiProperty({ description: 'Creation timestamp', type: Date })
   @CreateDateColumn()
   created_at: Date;
 
-  @ApiProperty({ description: 'Last update timestamp' })
+  @ApiProperty({ description: 'Last update timestamp', type: Date })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/api/rest/src/messages/messages.controller.ts
+++ b/api/rest/src/messages/messages.controller.ts
@@ -1,18 +1,18 @@
-// messages/messages.controller.ts
-import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, UseGuards, ParseIntPipe } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiBearerAuth,
   ApiBody,
   ApiParam,
+  ApiQuery,
   ApiUnauthorizedResponse,
   ApiForbiddenResponse,
   ApiBadRequestResponse,
   ApiOkResponse,
   ApiCreatedResponse,
+  ApiNotFoundResponse,
 } from '@nestjs/swagger';
-import { GetConversationsDto } from 'src/conversations/dto/get-conversations.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { GetMessagesDto, MessagePaginator } from './dto/get-messages.dto';
 import { Message } from './entities/message.entity';
@@ -20,57 +20,64 @@ import { MessagesService } from './messages.service';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { Roles } from '../common/decorators/roles.decorator';
-import { Permission } from '../common/enums/enums';
+import { Permission, SortOrder } from '../common/enums/enums';
+import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 
 
 @ApiTags('💬 Messages')
-@Controller('messages/conversations')
+@Controller('messages')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @ApiBearerAuth('JWT-auth')
 export class MessagesController {
   constructor(private readonly messagesService: MessagesService) {}
 
-  @Post(':id')
+  @Post()
   @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.CUSTOMER, Permission.STAFF)
   @ApiOperation({
     summary: 'Create a new message',
     description: 'Send a message in a conversation'
   })
-  @ApiParam({
-    name: 'id',
-    description: 'Conversation ID',
-    type: Number,
-    example: 1
-  })
   @ApiCreatedResponse({
     description: 'Message created successfully',
-    type: Message
+    type: () => Message
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @ApiBody({ type: CreateMessageDto })
-  createMessage(@Param('id') id: string, @Body() createMessageDto: CreateMessageDto) {
-    return this.messagesService.createMessage(createMessageDto);
+  create(
+    @Body() createMessageDto: CreateMessageDto,
+    @CurrentUser() user: any,
+  ): Promise<Message> {
+    if (user?.id && !createMessageDto.user_id) {
+      createMessageDto.user_id = user.id;
+    }
+    return this.messagesService.create(createMessageDto);
   }
 
-  @Get(':param')
+  @Get('conversation/:conversationId')
   @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.CUSTOMER, Permission.STAFF)
   @ApiOperation({
-    summary: 'Get messages',
-    description: 'Retrieve messages for a conversation'
+    summary: 'Get messages by conversation',
+    description: 'Retrieve messages for a specific conversation'
   })
   @ApiParam({
-    name: 'param',
-    description: 'Conversation ID or "all" for all messages',
-    example: '1'
+    name: 'conversationId',
+    description: 'Conversation ID',
+    type: Number,
+    example: 1,
   })
   @ApiOkResponse({
     description: 'Messages retrieved successfully',
-    type: MessagePaginator
+    type: () => MessagePaginator
   })
+  @ApiNotFoundResponse({ description: 'Conversation not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
-  getMessages(@Param('param') param: string, @Query() query: GetMessagesDto): Promise<MessagePaginator> {
-    return this.messagesService.getMessages(query);
+  findByConversation(
+    @Param('conversationId', ParseIntPipe) conversationId: number,
+    @Query() query: GetMessagesDto,
+    @CurrentUser() user: any,
+  ): Promise<MessagePaginator> {
+    return this.messagesService.findByConversation(conversationId, query, user);
   }
 }

--- a/api/rest/src/messages/messages.module.ts
+++ b/api/rest/src/messages/messages.module.ts
@@ -1,9 +1,12 @@
-// messages/messages.module.ts
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { MessagesController } from './messages.controller';
 import { MessagesService } from './messages.service';
+import { Message } from './entities/message.entity';
+import { Conversation } from 'src/conversations/entities/conversation.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Message, Conversation])],
   controllers: [MessagesController],
   providers: [MessagesService],
   exports: [MessagesService],

--- a/api/rest/src/messages/messages.service.ts
+++ b/api/rest/src/messages/messages.service.ts
@@ -1,54 +1,118 @@
-// messages/messages.service.ts
-import { Injectable } from '@nestjs/common';
-import { plainToClass } from 'class-transformer';
-import MessagesJson from '@db/messages.json';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { Message } from './entities/message.entity';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { GetMessagesDto, MessagePaginator } from './dto/get-messages.dto';
 import { paginate } from '../common/pagination/paginate';
-
-const messages = plainToClass(Message, MessagesJson);
+import { SortOrder } from 'src/common/enums/enums';
+import { Conversation } from 'src/conversations/entities/conversation.entity';
+import { MessageOrderByColumn } from 'src/common/enums/message-order-by.enum';
 
 @Injectable()
 export class MessagesService {
-  private messages: Message[] = messages;
+  constructor(
+    @InjectRepository(Message)
+    private messageRepository: Repository<Message>,
+    @InjectRepository(Conversation)
+    private conversationRepository: Repository<Conversation>,
+  ) {}
 
-  createMessage(createMessageDto: CreateMessageDto) {
-    return this.messages[0];
-  }
+  async create(createMessageDto: CreateMessageDto): Promise<Message> {
+    const conversation = await this.conversationRepository.findOne({
+      where: { id: createMessageDto.conversation_id },
+    });
 
-  getMessages({ search, limit, page, sortedBy = 'created_at', orderBy = 'DESC' }: GetMessagesDto): Promise<MessagePaginator> {
-    if (!page) page = 1;
-    if (!limit) limit = 30;
-    
-    let data: Message[] = [...this.messages];
-    
-    if (search) {
-      data = data.filter(m => 
-        m.body.toLowerCase().includes(search.toLowerCase())
+    if (!conversation) {
+      throw new NotFoundException(
+        `Conversation with ID ${createMessageDto.conversation_id} not found`,
       );
     }
-    
-    data.sort((a, b) => {
-      const aValue = a[sortedBy as keyof Message];
-      const bValue = b[sortedBy as keyof Message];
-      if (orderBy === 'ASC') {
-        return aValue > bValue ? 1 : -1;
-      } else {
-        return aValue < bValue ? 1 : -1;
-      }
+
+    const message = this.messageRepository.create({
+      conversation_id: createMessageDto.conversation_id,
+      user_id: createMessageDto.user_id,
+      body: createMessageDto.body,
     });
+
+    return this.messageRepository.save(message);
+  }
+
+  async findByConversation(
+    conversationId: number,
+    {
+      page = 1,
+      limit = 30,
+      search,
+      orderBy = MessageOrderByColumn.CREATED_AT,
+      sortedBy = SortOrder.DESC,
+    }: GetMessagesDto,
+    user?: any,
+  ): Promise<MessagePaginator> {
+    // Verify conversation exists
+    const conversation = await this.conversationRepository.findOne({
+      where: { id: conversationId },
+    });
+
+    if (!conversation) {
+      throw new NotFoundException(`Conversation with ID ${conversationId} not found`);
+    }
+
+    // Check permission
+    const isAdmin = user?.permissions?.includes('super_admin');
+    const isParticipant = conversation.user_id === user?.id || conversation.shop_id === user?.shop_id;
+
+    if (!isAdmin && !isParticipant) {
+      throw new ForbiddenException('You do not have permission to view messages in this conversation');
+    }
+
+    const queryBuilder = this.messageRepository
+      .createQueryBuilder('message')
+      .where('message.conversation_id = :conversationId', { conversationId });
+
+    if (search) {
+      queryBuilder.andWhere('LOWER(message.body) LIKE LOWER(:search)', {
+        search: `%${search}%`,
+      });
+    }
+
+    const orderColumn =
+      orderBy === MessageOrderByColumn.ID
+        ? 'message.id'
+        : orderBy === MessageOrderByColumn.UPDATED_AT
+          ? 'message.updated_at'
+          : 'message.created_at';
+
+    queryBuilder.orderBy(orderColumn, sortedBy === SortOrder.ASC ? 'ASC' : 'DESC');
+    queryBuilder.skip((page - 1) * limit).take(limit);
+
+    const [results, total] = await queryBuilder.getManyAndCount();
     
-    const startIndex = (page - 1) * limit;
-    const endIndex = page * limit;
-    const results = data.slice(startIndex, endIndex);
-    
-    const url = `/messages/conversations?limit=${limit}`;
-    const paginationInfo = paginate(data.length, page, limit, results.length, url);
-    
-    return Promise.resolve({
+    const url = `/messages/conversation/${conversationId}?limit=${limit}`;
+    const paginationInfo = paginate(total, page, limit, results.length, url);
+
+    return {
       data: results,
       ...paginationInfo,
+      current_page: page,
+      per_page: limit,
+      total,
+      last_page: Math.ceil(total / limit),
+      from: (page - 1) * limit + 1,
+      to: Math.min(page * limit, total),
+    };
+  }
+
+  // Helper method to get message by ID
+  async findById(id: number): Promise<Message> {
+    const message = await this.messageRepository.findOne({
+      where: { id },
     });
+    
+    if (!message) {
+      throw new NotFoundException(`Message with ID ${id} not found`);
+    }
+    
+    return message;
   }
 }


### PR DESCRIPTION
Replace in-memory messages with TypeORM-backed repository and enhance messages API. Adds Message entity relation to Conversation, soft-delete column, and MessageOrderByColumn enum. Updates DTOs (CreateMessageDto now requires conversation_id and optional user_id; GetMessagesDto adds search, enum-based orderBy/sortedBy and improved paginator shape). Controller routes and handlers were changed (POST /messages, GET /messages/conversation/:conversationId), inject current user, and use ParseIntPipe. MessagesService now uses repositories, validates conversation existence and permissions, supports search, ordering, pagination, and includes create, findByConversation and findById methods. Also registers Message and Conversation in MessagesModule via TypeOrmModule.forFeature.