### PR TITLE
feat: Implement newsletters API and service

### DIFF
--- a/api/rest/src/newsletters/dto/create-new-subscriber.dto.ts
+++ b/api/rest/src/newsletters/dto/create-new-subscriber.dto.ts
@@ -1,15 +1,25 @@
-// newsletters/dto/create-new-subscriber.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateNewSubscriberDto {
   @ApiProperty({
     description: 'Email address for newsletter subscription',
     example: 'user@example.com',
     format: 'email',
-    required: true
+    required: true,
+    type: String,
   })
   @IsEmail()
   @IsNotEmpty()
   email: string;
+
+  @ApiProperty({
+    description: 'Subscriber name',
+    example: 'John Doe',
+    required: false,
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  name?: string;
 }

--- a/api/rest/src/newsletters/dto/newsletter-response.dto.ts
+++ b/api/rest/src/newsletters/dto/newsletter-response.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
+
+export enum NewsletterStatus {
+  SUBSCRIBED = 'SUBSCRIBED',
+  UNSUBSCRIBED = 'UNSUBSCRIBED',
+}
+
+
+export class NewsletterSubscriptionResponse {
+  @ApiProperty({
+    description: 'Response message',
+    example: 'Your email successfully subscribed to newsletter',
+    type: String,
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'Subscription status',
+    enum: NewsletterStatus,
+    example: NewsletterStatus.SUBSCRIBED,
+    type: String,
+  })
+  status: NewsletterStatus;
+
+  @ApiProperty({
+    description: 'Subscriber email',
+    example: 'user@example.com',
+    type: String,
+  })
+  email: string;
+}
+
+export class NewsletterUnsubscribeResponse extends CoreMutationOutput {
+  @ApiProperty({
+    description: 'Unsubscription status',
+    enum: NewsletterStatus,
+    example: NewsletterStatus.UNSUBSCRIBED,
+    type: String,
+  })
+  status: NewsletterStatus;
+}

--- a/api/rest/src/newsletters/newsletters.controller.ts
+++ b/api/rest/src/newsletters/newsletters.controller.ts
@@ -1,47 +1,164 @@
-// newsletters/newsletters.controller.ts
-import { Body, Controller, Post, UseGuards, HttpCode, HttpStatus } from '@nestjs/common';
+import { Body, Controller, Post, Delete, Param, UseGuards, HttpCode, HttpStatus } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiBearerAuth,
   ApiBody,
+  ApiParam,
   ApiUnauthorizedResponse,
   ApiBadRequestResponse,
   ApiOkResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiForbiddenResponse,
 } from '@nestjs/swagger';
 import { NewslettersService } from './newsletters.service';
 import { CreateNewSubscriberDto } from './dto/create-new-subscriber.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { Public } from '../common/decorators/public.decorator';
-
+import { Roles } from '../common/decorators/roles.decorator';
+import { Permission } from '../common/enums/enums';
+import { NewsletterSubscriptionResponse, NewsletterUnsubscribeResponse } from './dto/newsletter-response.dto';
 
 @ApiTags('📧 Newsletters')
-@Controller('subscribe-to-newsletter')
-@UseGuards(JwtAuthGuard, RolesGuard)
-@ApiBearerAuth('JWT-auth')
+@Controller('newsletters')
 export class NewslettersController {
   constructor(private newslettersService: NewslettersService) {}
 
-  @Post()
+  @Post('subscribe')
   @Public()
-  @HttpCode(HttpStatus.OK)
+  @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     summary: 'Subscribe to newsletter',
     description: 'Subscribe a new email address to the newsletter'
   })
-  @ApiOkResponse({
+  @ApiCreatedResponse({
     description: 'Successfully subscribed to newsletter',
+    type: () => NewsletterSubscriptionResponse,
+  })
+  @ApiBadRequestResponse({ 
+    description: 'Invalid email address or email already subscribed',
     schema: {
       type: 'object',
       properties: {
-        message: { type: 'string', example: 'Your email successfully subscribed' }
-      }
-    }
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'string', example: 'Email already subscribed' },
+        error: { type: 'string', example: 'Bad Request' },
+      },
+    },
   })
-  @ApiBadRequestResponse({ description: 'Invalid email address' })
   @ApiBody({ type: CreateNewSubscriberDto })
-  async subscribeToNewsletter(@Body() body: CreateNewSubscriberDto) {
-    return this.newslettersService.subscribeToNewsletter(body);
+  async subscribe(@Body() body: CreateNewSubscriberDto): Promise<NewsletterSubscriptionResponse> {
+    return this.newslettersService.subscribe(body);
+  }
+
+  @Post('subscribe-to-newsletter')
+  @Public()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Subscribe to newsletter',
+    description: 'Subscribe a new email address to the newsletter'
+  })
+  @ApiCreatedResponse({
+    description: 'Successfully subscribed to newsletter',
+    type: () => NewsletterSubscriptionResponse,
+  })
+  @ApiBadRequestResponse({ 
+    description: 'Invalid email address or email already subscribed',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'string', example: 'Email already subscribed' },
+        error: { type: 'string', example: 'Bad Request' },
+      },
+    },
+  })
+  @ApiBody({ type: CreateNewSubscriberDto })
+  async subscribeToNewsletter(@Body() body: CreateNewSubscriberDto): Promise<NewsletterSubscriptionResponse> {
+    return this.newslettersService.subscribe(body);
+  }
+
+  @Delete('unsubscribe/:email')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Unsubscribe from newsletter',
+    description: 'Unsubscribe an email address from the newsletter'
+  })
+  @ApiParam({
+    name: 'email',
+    description: 'Email address to unsubscribe',
+    example: 'user@example.com',
+    type: String,
+  })
+  @ApiOkResponse({
+    description: 'Successfully unsubscribed from newsletter',
+    type: () => NewsletterUnsubscribeResponse,
+  })
+  @ApiNotFoundResponse({ description: 'Email not found in subscribers' })
+  @ApiBadRequestResponse({ description: 'Invalid email format' })
+  async unsubscribe(@Param('email') email: string): Promise<NewsletterUnsubscribeResponse> {
+    return this.newslettersService.unsubscribe(email);
+  }
+
+  @Delete('admin/:email')
+  @Roles(Permission.SUPER_ADMIN)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth('JWT-auth')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Admin remove subscriber',
+    description: 'Remove a subscriber from newsletter (Admin only)'
+  })
+  @ApiParam({
+    name: 'email',
+    description: 'Email address to remove',
+    example: 'user@example.com',
+    type: String,
+  })
+  @ApiOkResponse({
+    description: 'Subscriber removed successfully',
+    type: () => NewsletterUnsubscribeResponse,
+  })
+  @ApiNotFoundResponse({ description: 'Email not found in subscribers' })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  async adminRemove(@Param('email') email: string): Promise<NewsletterUnsubscribeResponse> {
+    return this.newslettersService.adminRemove(email);
+  }
+}
+
+@ApiTags('📧 Newsletters')
+@Controller()
+export class LegacyNewslettersController {
+  constructor(private newslettersService: NewslettersService) {}
+
+  @Post('subscribe-to-newsletter')
+  @Public()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Subscribe to newsletter',
+    description: 'Subscribe a new email address to the newsletter'
+  })
+  @ApiCreatedResponse({
+    description: 'Successfully subscribed to newsletter',
+    type: () => NewsletterSubscriptionResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid email address or email already subscribed',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'string', example: 'Email already subscribed' },
+        error: { type: 'string', example: 'Bad Request' },
+      },
+    },
+  })
+  @ApiBody({ type: CreateNewSubscriberDto })
+  async subscribe(@Body() body: CreateNewSubscriberDto): Promise<NewsletterSubscriptionResponse> {
+    return this.newslettersService.subscribe(body);
   }
 }

--- a/api/rest/src/newsletters/newsletters.module.ts
+++ b/api/rest/src/newsletters/newsletters.module.ts
@@ -1,10 +1,9 @@
-// newsletters/newsletters.module.ts
 import { Module } from '@nestjs/common';
-import { NewslettersController } from './newsletters.controller';
+import { LegacyNewslettersController, NewslettersController } from './newsletters.controller';
 import { NewslettersService } from './newsletters.service';
 
 @Module({
-  controllers: [NewslettersController],
+  controllers: [NewslettersController, LegacyNewslettersController],
   providers: [NewslettersService],
   exports: [NewslettersService],
 })

--- a/api/rest/src/newsletters/newsletters.service.ts
+++ b/api/rest/src/newsletters/newsletters.service.ts
@@ -1,13 +1,141 @@
-// newsletters/newsletters.service.ts
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException, NotFoundException, ConflictException, Logger } from '@nestjs/common';
 import { CreateNewSubscriberDto } from './dto/create-new-subscriber.dto';
+import { NewsletterStatus, NewsletterSubscriptionResponse, NewsletterUnsubscribeResponse } from './dto/newsletter-response.dto';
+
+interface Subscriber {
+  email: string;
+  name?: string;
+  subscribedAt: Date;
+  status: NewsletterStatus;
+}
 
 @Injectable()
 export class NewslettersService {
-  async subscribeToNewsletter({ email }: CreateNewSubscriberDto) {
-    // TODO: Save to database
-    return {
-      message: 'Your email successfully subscribed'
+  private readonly logger = new Logger(NewslettersService.name);
+  private subscribers: Map<string, Subscriber> = new Map();
+
+  async subscribe(subscribeDto: CreateNewSubscriberDto): Promise<NewsletterSubscriptionResponse> {
+    const { email, name } = subscribeDto;
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(normalizedEmail)) {
+      throw new BadRequestException('Invalid email format');
+    }
+
+    // Check if already subscribed
+    const existing = this.subscribers.get(normalizedEmail);
+    
+    if (existing) {
+      if (existing.status === NewsletterStatus.SUBSCRIBED) {
+        throw new ConflictException('Email already subscribed to newsletter');
+      } else if (existing.status === NewsletterStatus.UNSUBSCRIBED) {
+        // Reactivate subscription
+        existing.status = NewsletterStatus.SUBSCRIBED;
+        existing.name = name || existing.name;
+        existing.subscribedAt = new Date();
+        this.subscribers.set(normalizedEmail, existing);
+        
+        this.logger.log(`Email resubscribed: ${normalizedEmail}`);
+        
+        return {
+          message: 'Email successfully resubscribed to newsletter',
+          status: NewsletterStatus.SUBSCRIBED,
+          email: normalizedEmail,
+        };
+      }
+    }
+
+    // Create new subscriber
+    const newSubscriber: Subscriber = {
+      email: normalizedEmail,
+      name: name,
+      subscribedAt: new Date(),
+      status: NewsletterStatus.SUBSCRIBED,
     };
+
+    this.subscribers.set(normalizedEmail, newSubscriber);
+    this.logger.log(`New subscriber added: ${normalizedEmail}`);
+    this.logger.log(`Total subscribers: ${this.subscribers.size}`);
+
+    return {
+      message: 'Your email successfully subscribed to newsletter',
+      status: NewsletterStatus.SUBSCRIBED,
+      email: normalizedEmail,
+    };
+  }
+
+  async unsubscribe(email: string): Promise<NewsletterUnsubscribeResponse> {
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(normalizedEmail)) {
+      throw new BadRequestException('Invalid email format');
+    }
+
+    const subscriber = this.subscribers.get(normalizedEmail);
+
+    if (!subscriber) {
+      throw new NotFoundException(`Email ${email} not found in subscribers`);
+    }
+
+    if (subscriber.status === NewsletterStatus.UNSUBSCRIBED) {
+      return {
+        success: true,
+        message: 'Email already unsubscribed from newsletter',
+        status: NewsletterStatus.UNSUBSCRIBED,
+      };
+    }
+
+    subscriber.status = NewsletterStatus.UNSUBSCRIBED;
+    this.subscribers.set(normalizedEmail, subscriber);
+    this.logger.log(`Email unsubscribed: ${normalizedEmail}`);
+
+    return {
+      success: true,
+      message: 'Successfully unsubscribed from newsletter',
+      status: NewsletterStatus.UNSUBSCRIBED,
+    };
+  }
+
+  async adminRemove(email: string): Promise<NewsletterUnsubscribeResponse> {
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(normalizedEmail)) {
+      throw new BadRequestException('Invalid email format');
+    }
+
+    const subscriber = this.subscribers.get(normalizedEmail);
+
+    if (!subscriber) {
+      throw new NotFoundException(`Email ${email} not found in subscribers`);
+    }
+
+    // Remove from subscribers list (hard delete for admin)
+    this.subscribers.delete(normalizedEmail);
+    this.logger.log(`Admin removed subscriber: ${normalizedEmail}`);
+    this.logger.log(`Total subscribers: ${this.subscribers.size}`);
+
+    return {
+      success: true,
+      message: `Subscriber with email ${email} removed successfully`,
+      status: NewsletterStatus.UNSUBSCRIBED,
+    };
+  }
+
+  // Helper method to get all subscribers (for internal use)
+  getAllSubscribers(): Subscriber[] {
+    return Array.from(this.subscribers.values());
+  }
+
+  // Helper method to get active subscribers count
+  getActiveSubscribersCount(): number {
+    return Array.from(this.subscribers.values()).filter(
+      s => s.status === NewsletterStatus.SUBSCRIBED
+    ).length;
   }
 }

--- a/shop/src/framework/rest/client/api-endpoints.ts
+++ b/shop/src/framework/rest/client/api-endpoints.ts
@@ -31,7 +31,7 @@ export const API_ENDPOINTS = {
   USERS_RESET_PASSWORD: '/reset-password',
   USERS_CHANGE_PASSWORD: '/change-password',
   USERS_LOGOUT: '/logout',
-  USERS_SUBSCRIBE_TO_NEWSLETTER: '/subscribe-to-newsletter',
+  USERS_SUBSCRIBE_TO_NEWSLETTER: '/newsletters/subscribe',
   USERS_CONTACT_US: '/contact-us',
   USERS_WISHLIST: '/my-wishlists',
   WISHLIST: '/wishlists',


### PR DESCRIPTION
Add newsletter subscription functionality: introduce CreateNewSubscriberDto (adds optional name), new response DTOs and NewsletterStatus enum. Replace legacy single endpoint with a /newsletters controller exposing subscribe, unsubscribe and admin remove endpoints (with proper Swagger docs, guards and role checks) while keeping a LegacyNewslettersController for backward compatibility. Implement NewslettersService with in-memory subscriber storage, email validation, subscribe/resubscribe, unsubscribe and adminRemove logic, plus helper methods and logging. Register both controllers in the module and update frontend API endpoint to /newsletters/subscribe.