### PR TITLE
refactor: notify-logs API, DTOs, service and entity

### DIFF
--- a/api/rest/src/common/enums/notify-logs-order-by.enum.ts
+++ b/api/rest/src/common/enums/notify-logs-order-by.enum.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum NotifyLogsOrderByColumn {
+  CREATED_AT = 'CREATED_AT',
+  UPDATED_AT = 'UPDATED_AT',
+}

--- a/api/rest/src/notify-logs/dto/get-notify-logs.dto.ts
+++ b/api/rest/src/notify-logs/dto/get-notify-logs.dto.ts
@@ -1,46 +1,95 @@
-// notify-logs/dto/get-notify-logs.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
 import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
-import { Paginator } from 'src/common/dto/paginator.dto';
+import { IsOptional, IsString, IsNumber, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SortOrder } from 'src/common/enums/enums';
 import { NotifyLogs } from '../entities/notify-logs.entity';
+import { NotifyLogsOrderByColumn } from 'src/common/enums/notify-logs-order-by.enum';
 
-export class NotifyLogsPaginator extends Paginator<NotifyLogs> {
-  @ApiProperty({ type: [NotifyLogs] })
+export class NotifyLogsPaginator {
+  @ApiProperty({ type: () => [NotifyLogs], description: 'Array of notification logs' })
   data: NotifyLogs[];
+
+  @ApiProperty({ example: 1, type: Number, description: 'Current page number' })
+  current_page: number;
+
+  @ApiProperty({ example: 30, type: Number, description: 'Items per page' })
+  per_page: number;
+
+  @ApiProperty({ example: 100, type: Number, description: 'Total items count' })
+  total: number;
+
+  @ApiProperty({ example: 10, type: Number, description: 'Last page number' })
+  last_page: number;
+
+  @ApiProperty({ example: '/notify-logs?page=1', type: String, description: 'First page URL' })
+  first_page_url: string;
+
+  @ApiProperty({ example: '/notify-logs?page=10', type: String, description: 'Last page URL' })
+  last_page_url: string;
+
+  @ApiProperty({ example: '/notify-logs?page=2', nullable: true, type: String, description: 'Next page URL' })
+  next_page_url: string | null;
+
+  @ApiProperty({ example: '/notify-logs?page=1', nullable: true, type: String, description: 'Previous page URL' })
+  prev_page_url: string | null;
+
+  @ApiProperty({ example: 1, type: Number, description: 'Starting item index' })
+  from: number;
+
+  @ApiProperty({ example: 30, type: Number, description: 'Ending item index' })
+  to: number;
 }
 
 export class GetNotifyLogsDto extends PaginationArgs {
   @ApiProperty({
     description: 'Order by column',
-    enum: ['CREATED_AT', 'UPDATED_AT'],
-    required: false
+    enum: NotifyLogsOrderByColumn,
+    required: false,
+    default: NotifyLogsOrderByColumn.CREATED_AT,
   })
-  orderBy?: QueryReviewsOrderByColumn;
+  @IsOptional()
+  @IsEnum(NotifyLogsOrderByColumn)
+  orderBy?: NotifyLogsOrderByColumn = NotifyLogsOrderByColumn.CREATED_AT;
 
   @ApiProperty({
     description: 'Sort order',
     enum: SortOrder,
     required: false,
-    default: SortOrder.DESC
+    default: SortOrder.DESC,
   })
-  sortedBy?: SortOrder;
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortedBy?: SortOrder = SortOrder.DESC;
 
   @ApiProperty({
     description: 'Search term',
-    required: false
+    required: false,
+    type: String,
+    example: 'order',
   })
+  @IsOptional()
+  @IsString()
   search?: string;
 
   @ApiProperty({
-    description: 'Receiver ID',
+    description: 'Receiver ID or email',
     example: 1,
-    required: false
+    required: false,
+    type: Number,
   })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   receiver?: number;
-}
 
-export enum QueryReviewsOrderByColumn {
-  CREATED_AT = 'CREATED_AT',
-  UPDATED_AT = 'UPDATED_AT',
+  @ApiProperty({
+    description: 'Filter by read status',
+    example: false,
+    required: false,
+    type: Boolean,
+  })
+  @IsOptional()
+  @Type(() => Boolean)
+  is_read?: boolean;
 }

--- a/api/rest/src/notify-logs/entities/notify-logs.entity.ts
+++ b/api/rest/src/notify-logs/entities/notify-logs.entity.ts
@@ -1,23 +1,55 @@
-// notify-logs/entities/notify-logs.entity.ts
 import { ApiProperty } from '@nestjs/swagger';
 import { CoreEntity } from 'src/common/entities/core.entity';
+import { DeleteDateColumn } from 'typeorm';
 
 export class NotifyLogs extends CoreEntity {
-  @ApiProperty({ description: 'Receiver of notification', example: 'user@example.com' })
+  @ApiProperty({ 
+    description: 'Receiver of notification', 
+    example: 'user@example.com',
+    type: String,
+  })
   receiver: string;
 
-  @ApiProperty({ description: 'Sender of notification', example: 'system@example.com' })
+  @ApiProperty({ 
+    description: 'Sender of notification', 
+    example: 'system@example.com',
+    type: String,
+  })
   sender: string;
 
-  @ApiProperty({ description: 'Type of notification', example: 'order_status' })
+  @ApiProperty({ 
+    description: 'Type of notification', 
+    example: 'order_status',
+    type: String,
+  })
   notify_type: string;
 
-  @ApiProperty({ description: 'Receiver type', example: 'customer' })
+  @ApiProperty({ 
+    description: 'Receiver type', 
+    example: 'customer',
+    type: String,
+  })
   notify_receiver_type: string;
 
-  @ApiProperty({ description: 'Read status', example: false })
+  @ApiProperty({ 
+    description: 'Read status', 
+    example: false,
+    type: Boolean,
+  })
   is_read: boolean;
 
-  @ApiProperty({ description: 'Notification text content', example: 'Your order has been shipped' })
+  @ApiProperty({ 
+    description: 'Notification text content', 
+    example: 'Your order has been shipped',
+    type: String,
+  })
   notify_text: string;
+
+  @ApiProperty({ 
+    description: 'Soft delete timestamp', 
+    required: false,
+    type: Date,
+  })
+  @DeleteDateColumn()
+  deleted_at?: Date;
 }

--- a/api/rest/src/notify-logs/notify-logs.controller.ts
+++ b/api/rest/src/notify-logs/notify-logs.controller.ts
@@ -1,4 +1,3 @@
-// notify-logs/notify-logs.controller.ts
 import {
   Body,
   Controller,
@@ -17,6 +16,7 @@ import {
   ApiOperation,
   ApiBearerAuth,
   ApiParam,
+  ApiQuery,
   ApiUnauthorizedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
@@ -47,36 +47,38 @@ export class NotifyLogsController {
   })
   @ApiOkResponse({
     description: 'Notify logs retrieved successfully',
-    type: NotifyLogsPaginator
+    type: () => NotifyLogsPaginator
   })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
-  findAll(@Query() query: GetNotifyLogsDto) {
-    return this.notifyLogsService.findAllNotifyLogs(query);
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  findAll(@Query() query: GetNotifyLogsDto): Promise<NotifyLogsPaginator> {
+    return this.notifyLogsService.findAll(query);
   }
 
-  @Get(':param')
+  @Get(':id')
   @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.CUSTOMER)
   @ApiOperation({
     summary: 'Get notify log by ID',
     description: 'Retrieve a single notification log by ID'
   })
   @ApiParam({
-    name: 'param',
+    name: 'id',
     description: 'Notify log ID',
     type: Number,
-    example: 1
+    example: 1,
   })
   @ApiOkResponse({
     description: 'Notify log retrieved successfully',
-    type: NotifyLogs
+    type: () => NotifyLogs
   })
   @ApiNotFoundResponse({ description: 'Notify log not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
-  getNotifyLog(@Param('param') param: string, @Query('language') language: string) {
-    return this.notifyLogsService.getNotifyLog(param, language);
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<NotifyLogs> {
+    return this.notifyLogsService.findOne(id);
   }
 
-  @Put(':id')
+  @Put(':id/read')
   @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER, Permission.CUSTOMER)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
@@ -87,19 +89,20 @@ export class NotifyLogsController {
     name: 'id',
     description: 'Notify log ID',
     type: Number,
-    example: 1
+    example: 1,
   })
   @ApiOkResponse({
     description: 'Notify log marked as read',
-    type: NotifyLogs
+    type: () => NotifyLogs
   })
   @ApiNotFoundResponse({ description: 'Notify log not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
-  readNotifyLogs(@Param('id', ParseIntPipe) id: number) {
-    return this.notifyLogsService.readNotifyLog(id);
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  markAsRead(@Param('id', ParseIntPipe) id: number): Promise<NotifyLogs> {
+    return this.notifyLogsService.markAsRead(id);
   }
 
-  @Put('read-all/:id')
+  @Put('read-all/:userId')
   @Roles(Permission.SUPER_ADMIN, Permission.STORE_OWNER)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
@@ -107,19 +110,20 @@ export class NotifyLogsController {
     description: 'Mark all notifications as read for a user'
   })
   @ApiParam({
-    name: 'id',
+    name: 'userId',
     description: 'User ID',
     type: Number,
-    example: 1
+    example: 1,
   })
   @ApiOkResponse({
     description: 'All notify logs marked as read',
     type: CoreMutationOutput
   })
+  @ApiNotFoundResponse({ description: 'No notify logs found for user' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
-  notifyLogAllRead(@Param('id', ParseIntPipe) id: number) {
-    return this.notifyLogsService.readAllNotifyLogs(id);
+  markAllAsRead(@Param('userId', ParseIntPipe) userId: number): Promise<CoreMutationOutput> {
+    return this.notifyLogsService.markAllAsRead(userId);
   }
 
   @Delete(':id')
@@ -127,13 +131,13 @@ export class NotifyLogsController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Delete notify log',
-    description: 'Delete a notification log by ID (Admin only)'
+    description: 'Soft delete a notification log by ID (Admin only)'
   })
   @ApiParam({
     name: 'id',
     description: 'Notify log ID',
     type: Number,
-    example: 1
+    example: 1,
   })
   @ApiOkResponse({
     description: 'Notify log deleted successfully',
@@ -142,7 +146,7 @@ export class NotifyLogsController {
   @ApiNotFoundResponse({ description: 'Notify log not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
-  deleteNotifyLog(@Param('id', ParseIntPipe) id: number) {
+  remove(@Param('id', ParseIntPipe) id: number): Promise<CoreMutationOutput> {
     return this.notifyLogsService.remove(id);
   }
 }

--- a/api/rest/src/notify-logs/notify-logs.module.ts
+++ b/api/rest/src/notify-logs/notify-logs.module.ts
@@ -1,4 +1,3 @@
-// notify-logs/notify-logs.module.ts
 import { Module } from '@nestjs/common';
 import { NotifyLogsController } from './notify-logs.controller';
 import { NotifyLogsService } from './notify-logs.service';

--- a/api/rest/src/notify-logs/notify-logs.service.ts
+++ b/api/rest/src/notify-logs/notify-logs.service.ts
@@ -1,55 +1,61 @@
-// notify-logs/notify-logs.service.ts
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { NotifyLogs } from './entities/notify-logs.entity';
-import { plainToClass } from 'class-transformer';
-import Fuse from 'fuse.js';
-import { paginate } from 'src/common/pagination/paginate';
-import { GetNotifyLogsDto, NotifyLogsPaginator, QueryReviewsOrderByColumn } from './dto/get-notify-logs.dto';
+import { GetNotifyLogsDto, NotifyLogsPaginator } from './dto/get-notify-logs.dto';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
+import { paginate } from 'src/common/pagination/paginate';
+import { SortOrder } from 'src/common/enums/enums';
+import { NotifyLogsOrderByColumn } from 'src/common/enums/notify-logs-order-by.enum';
 
-const notifyLogs = plainToClass(NotifyLogs, []);
-const options = {
-  keys: ['notify_type', 'notify_text'],
-  threshold: 0.3,
-};
-const fuse = new Fuse(notifyLogs, options);
 
 @Injectable()
 export class NotifyLogsService {
-  private notifyLogs: NotifyLogs[] = notifyLogs;
+  private notifyLogs: NotifyLogs[] = [];
 
-  findAllNotifyLogs({ search, limit, page, receiver, orderBy = QueryReviewsOrderByColumn.CREATED_AT, sortedBy = SortOrder.DESC }: GetNotifyLogsDto): NotifyLogsPaginator {
-    if (!page) page = 1;
-    if (!limit) limit = 10;
-    
+  async findAll({
+    page = 1,
+    limit = 30,
+    search,
+    receiver,
+    is_read,
+    orderBy = NotifyLogsOrderByColumn.CREATED_AT,
+    sortedBy = SortOrder.DESC,
+  }: GetNotifyLogsDto): Promise<NotifyLogsPaginator> {
     let data: NotifyLogs[] = [...this.notifyLogs];
 
     if (receiver) {
       data = data.filter(log => log.receiver === receiver.toString());
     }
 
-    if (search) {
-      const parseSearchParams = search.split(';');
-      for (const searchParam of parseSearchParams) {
-        const [key, value] = searchParam.split(':');
-        if (key === 'notify_type' && value) {
-          data = fuse.search(value)?.map(({ item }) => item);
-        } else if (key === 'is_read' && value) {
-          data = data.filter(log => log.is_read === (value === 'true'));
-        } else {
-          data = data.filter(log => 
-            log.notify_type?.toLowerCase().includes(search.toLowerCase()) ||
-            log.notify_text?.toLowerCase().includes(search.toLowerCase())
-          );
-        }
-      }
+    if (is_read !== undefined) {
+      data = data.filter(log => log.is_read === is_read);
     }
 
-    const sortKey = orderBy === QueryReviewsOrderByColumn.CREATED_AT ? 'created_at' : 'updated_at';
+    if (search) {
+      const searchLower = search.toLowerCase();
+      data = data.filter(log => 
+        log.notify_type?.toLowerCase().includes(searchLower) ||
+        log.notify_text?.toLowerCase().includes(searchLower) ||
+        log.receiver?.toLowerCase().includes(searchLower)
+      );
+    }
+
+    let orderColumn: string;
+    switch (orderBy) {
+      case NotifyLogsOrderByColumn.UPDATED_AT:
+        orderColumn = 'updated_at';
+        break;
+      default:
+        orderColumn = 'created_at';
+    }
+
     data.sort((a, b) => {
-      const aValue = a[sortKey as keyof NotifyLogs];
-      const bValue = b[sortKey as keyof NotifyLogs];
+      const aValue = a[orderColumn as keyof NotifyLogs];
+      const bValue = b[orderColumn as keyof NotifyLogs];
+
+      if (aValue === undefined && bValue === undefined) return 0;
+      if (aValue === undefined) return sortedBy === SortOrder.ASC ? -1 : 1;
+      if (bValue === undefined) return sortedBy === SortOrder.ASC ? 1 : -1;
+
       if (sortedBy === SortOrder.ASC) {
         return aValue > bValue ? 1 : -1;
       } else {
@@ -57,40 +63,50 @@ export class NotifyLogsService {
       }
     });
 
+    const total = data.length;
     const startIndex = (page - 1) * limit;
-    const endIndex = page * limit;
+    const endIndex = startIndex + limit;
     const results = data.slice(startIndex, endIndex);
     
-    const url = `/notify-logs?search=${search}&limit=${limit}`;
-    
+    const url = `/notify-logs?limit=${limit}`;
+    const paginationInfo = paginate(total, page, limit, results.length, url);
+
     return {
       data: results,
-      ...paginate(data.length, page, limit, results.length, url),
+      ...paginationInfo,
+      current_page: page,
+      per_page: limit,
+      total,
+      last_page: Math.ceil(total / limit),
+      from: (page - 1) * limit + 1,
+      to: Math.min(page * limit, total),
     };
   }
 
-  getNotifyLog(param: string, language: string): NotifyLogs {
-    const notifyLog = this.notifyLogs.find((p) => p.id === Number(param));
-    
-    if (!notifyLog) {
-      throw new NotFoundException(`Notify log with ID ${param} not found`);
-    }
-    
-    return notifyLog;
-  }
-
-  readNotifyLog(id: number): NotifyLogs {
+  async findOne(id: number): Promise<NotifyLogs> {
     const notifyLog = this.notifyLogs.find((p) => p.id === id);
     
     if (!notifyLog) {
       throw new NotFoundException(`Notify log with ID ${id} not found`);
     }
     
-    notifyLog.is_read = true;
     return notifyLog;
   }
 
-  readAllNotifyLogs(userId: number): CoreMutationOutput {
+  async markAsRead(id: number): Promise<NotifyLogs> {
+    const notifyLog = await this.findOne(id);
+    
+    notifyLog.is_read = true;
+    
+    const index = this.notifyLogs.findIndex(log => log.id === id);
+    if (index !== -1) {
+      this.notifyLogs[index] = notifyLog;
+    }
+    
+    return notifyLog;
+  }
+
+  async markAllAsRead(userId: number): Promise<CoreMutationOutput> {
     const userLogs = this.notifyLogs.filter(log => log.receiver === userId.toString());
     
     if (userLogs.length === 0) {
@@ -107,7 +123,7 @@ export class NotifyLogsService {
     };
   }
 
-  remove(id: number): CoreMutationOutput {
+  async remove(id: number): Promise<CoreMutationOutput> {
     const index = this.notifyLogs.findIndex(log => log.id === id);
     
     if (index === -1) {
@@ -120,5 +136,31 @@ export class NotifyLogsService {
       success: true,
       message: 'Notify log deleted successfully',
     };
+  }
+
+  // Helper method to create a new notification log
+  async createNotifyLog(notifyData: Partial<NotifyLogs>): Promise<NotifyLogs> {
+    const newNotifyLog: NotifyLogs = {
+      id: this.notifyLogs.length + 1,
+      receiver: notifyData.receiver || '',
+      sender: notifyData.sender || 'system',
+      notify_type: notifyData.notify_type || '',
+      notify_receiver_type: notifyData.notify_receiver_type || 'customer',
+      is_read: false,
+      notify_text: notifyData.notify_text || '',
+      created_at: new Date(),
+      updated_at: new Date(),
+    } as NotifyLogs;
+    
+    this.notifyLogs.unshift(newNotifyLog);
+    
+    return newNotifyLog;
+  }
+
+  // Helper method to get unread count for a user
+  async getUnreadCount(receiverId: string): Promise<number> {
+    return this.notifyLogs.filter(log => 
+      log.receiver === receiverId && !log.is_read
+    ).length;
   }
 }


### PR DESCRIPTION
Introduce structured ordering enum and tighten DTOs/validation; add an explicit NotifyLogsPaginator shape with full pagination fields. Update NotifyLogs entity (typed ApiProperty fields, soft-delete column deleted_at). Refactor controller routes and handlers (renamed methods, changed routes: GET :id, PUT :id/read, PUT read-all/:userId, DELETE stays but handler renamed), improve Swagger decorators and add forbidden/validation responses. Rework service to async operations, remove Fuse.js search, simplify search & add is_read and receiver filtering, normalize ordering via NotifyLogsOrderByColumn, implement consistent sorting/pagination using paginate(), and add helper methods createNotifyLog and getUnreadCount. Misc: clean imports and enum usages across files.