### PR TITLE
Refactor : ownership-transfer to TypeORM & enums

### DIFF
--- a/api/rest/src/common/enums/ownership-transfer.enum.ts
+++ b/api/rest/src/common/enums/ownership-transfer.enum.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum OwnershipTransferStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  COMPLETED = 'completed',
+}
+
+export enum OwnershipTransferOrderByColumn {
+  CREATED_AT = 'CREATED_AT',
+  UPDATED_AT = 'UPDATED_AT',
+  TRANSACTION_IDENTIFIER = 'TRANSACTION_IDENTIFIER',
+  STATUS = 'STATUS',
+}

--- a/api/rest/src/config/database/seeders/ownership-transfer-seeder.service.ts
+++ b/api/rest/src/config/database/seeders/ownership-transfer-seeder.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { OwnershipTransfer } from '../../../ownership-transfer/entities/ownership-transfer.entity';
 import ownershipTransferJson from '@db/ownership-transfer.json';
-import { User } from '../../../users/entities/user.entity';
+import { OwnershipTransferStatus } from 'src/common/enums/ownership-transfer.enum';
 
 type OwnershipTransferSeedUser = {
   id: number;
@@ -22,7 +22,7 @@ type OwnershipTransferSeedItem = {
   current_owner?: OwnershipTransferSeedUser | null;
   message?: string | null;
   created_by: number | string;
-  status: string;
+  status: OwnershipTransferStatus;
   order_info?: OwnershipTransfer['order_info'] | null;
   created_at?: string;
   updated_at?: string;
@@ -59,7 +59,7 @@ export class OwnershipTransferSeederService {
       
       // Log transfer details
       savedTransfers.forEach(transfer => {
-        this.logger.debug(`   - Transfer #${transfer.id}: ${transfer.transaction_identifier} - ${transfer.status} (${transfer.previous_owner?.name} → ${transfer.current_owner?.name})`);
+        this.logger.debug(`   - Transfer #${transfer.id}: ${transfer.transaction_identifier} - ${transfer.status} (previous_owner_id=${transfer.previous_owner_id}, current_owner_id=${transfer.current_owner_id})`);
       });
       
       return savedTransfers;
@@ -124,8 +124,8 @@ export class OwnershipTransferSeederService {
 
     transfer.id = item.id;
     transfer.transaction_identifier = item.transaction_identifier;
-    transfer.previous_owner = this.mapUser(item.previous_owner);
-    transfer.current_owner = this.mapUser(item.current_owner);
+    transfer.previous_owner_id = item.previous_owner?.id ?? null;
+    transfer.current_owner_id = item.current_owner?.id ?? null;
     transfer.message = item.message ?? null;
     transfer.created_by = String(item.created_by);
     transfer.status = item.status;
@@ -143,17 +143,6 @@ export class OwnershipTransferSeederService {
     transfer.updated_at = this.parseDate(item.updated_at);
 
     return transfer;
-  }
-
-  private mapUser(user: OwnershipTransferSeedUser | null | undefined): User {
-    const mappedUser = new User();
-    mappedUser.id = user?.id ?? 0;
-    mappedUser.name = user?.name ?? '';
-    mappedUser.email = user?.email ?? '';
-    mappedUser.is_active = Boolean(user?.is_active);
-    mappedUser.created_at = this.parseDate(user?.created_at);
-    mappedUser.updated_at = this.parseDate(user?.updated_at);
-    return mappedUser;
   }
 
   private parseDate(value?: string): Date {

--- a/api/rest/src/ownership-transfer/dto/create-ownership-transfer.dto.ts
+++ b/api/rest/src/ownership-transfer/dto/create-ownership-transfer.dto.ts
@@ -1,29 +1,15 @@
-// ownership-transfer/dto/create-ownership-transfer.dto.ts
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsString, IsOptional, IsEnum } from 'class-validator';
-import { OwnershipTransfer } from '../entities/ownership-transfer.entity';
-
-export enum OwnershipTransferStatus {
-  PENDING = 'pending',
-  APPROVED = 'approved',
-  REJECTED = 'rejected',
-  COMPLETED = 'completed',
-}
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsEnum, IsNumber, IsObject, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { User } from 'src/users/entities/user.entity';
+import { OwnershipTransferStatus } from 'src/common/enums/ownership-transfer.enum';
 
 export class CreateOwnershipTransferDto {
   @ApiProperty({
-    description: 'Transfer status',
-    enum: OwnershipTransferStatus,
-    required: false,
-    default: 'pending'
-  })
-  @IsOptional()
-  @IsEnum(OwnershipTransferStatus)
-  status?: string;
-  @ApiProperty({
     description: 'Transaction identifier',
     example: '2024-08-03-0001',
-    required: false
+    required: false,
+    type: String,
   })
   @IsOptional()
   @IsString()
@@ -32,23 +18,28 @@ export class CreateOwnershipTransferDto {
   @ApiProperty({
     description: 'Previous owner ID',
     example: 48,
-    required: false
+    required: false,
+    type: Number,
   })
   @IsOptional()
+  @IsNumber()
   previous_owner_id?: number;
 
   @ApiProperty({
     description: 'Current owner ID',
     example: 49,
-    required: false
+    required: false,
+    type: Number,
   })
   @IsOptional()
+  @IsNumber()
   current_owner_id?: number;
 
   @ApiProperty({
     description: 'Transfer message',
     example: 'Transferring shop ownership',
-    required: false
+    required: false,
+    type: String,
   })
   @IsOptional()
   @IsString()
@@ -57,8 +48,20 @@ export class CreateOwnershipTransferDto {
   @ApiProperty({
     description: 'Created by user ID',
     example: 6,
-    required: false
+    required: false,
+    type: Number,
   })
   @IsOptional()
+  @IsNumber()
   created_by?: number;
+
+  @ApiProperty({
+    description: 'Transfer status',
+    enum: OwnershipTransferStatus,
+    required: false,
+    default: OwnershipTransferStatus.PENDING,
+  })
+  @IsOptional()
+  @IsEnum(OwnershipTransferStatus)
+  status?: OwnershipTransferStatus = OwnershipTransferStatus.PENDING;
 }

--- a/api/rest/src/ownership-transfer/dto/get-ownership-transfer.dto.ts
+++ b/api/rest/src/ownership-transfer/dto/get-ownership-transfer.dto.ts
@@ -1,61 +1,105 @@
-// ownership-transfer/dto/get-ownership-transfer.dto.ts
 import { ApiProperty } from '@nestjs/swagger';
-import { SortOrder } from 'src/common/dto/generic-conditions.dto';
 import { PaginationArgs } from 'src/common/dto/pagination-args.dto';
-import { Paginator } from 'src/common/dto/paginator.dto';
+import { IsOptional, IsString, IsNumber, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SortOrder } from 'src/common/enums/enums';
 import { OwnershipTransfer } from '../entities/ownership-transfer.entity';
+import { OwnershipTransferOrderByColumn, OwnershipTransferStatus } from 'src/common/enums/ownership-transfer.enum';
 
-export class OwnershipTransferPaginator extends Paginator<OwnershipTransfer> {
-  @ApiProperty({ type: [OwnershipTransfer] })
+export class OwnershipTransferPaginator {
+  @ApiProperty({ type: () => [OwnershipTransfer], description: 'Array of ownership transfers' })
   data: OwnershipTransfer[];
+
+  @ApiProperty({ example: 1, type: Number, description: 'Current page number' })
+  current_page: number;
+
+  @ApiProperty({ example: 30, type: Number, description: 'Items per page' })
+  per_page: number;
+
+  @ApiProperty({ example: 100, type: Number, description: 'Total items count' })
+  total: number;
+
+  @ApiProperty({ example: 10, type: Number, description: 'Last page number' })
+  last_page: number;
+
+  @ApiProperty({ example: '/ownership-transfer?page=1', type: String, description: 'First page URL' })
+  first_page_url: string;
+
+  @ApiProperty({ example: '/ownership-transfer?page=10', type: String, description: 'Last page URL' })
+  last_page_url: string;
+
+  @ApiProperty({ example: '/ownership-transfer?page=2', nullable: true, type: String, description: 'Next page URL' })
+  next_page_url: string | null;
+
+  @ApiProperty({ example: '/ownership-transfer?page=1', nullable: true, type: String, description: 'Previous page URL' })
+  prev_page_url: string | null;
+
+  @ApiProperty({ example: 1, type: Number, description: 'Starting item index' })
+  from: number;
+
+  @ApiProperty({ example: 30, type: Number, description: 'Ending item index' })
+  to: number;
 }
 
 export class GetOwnershipTransferDto extends PaginationArgs {
   @ApiProperty({
     description: 'Order by column',
-    enum: ['CREATED_AT', 'UPDATED_AT', 'TRANSACTION_IDENTIFIER'],
-    required: false
+    enum: OwnershipTransferOrderByColumn,
+    required: false,
+    default: OwnershipTransferOrderByColumn.CREATED_AT,
   })
-  orderBy?: QueryOwnershipTransferOrderByColumn;
+  @IsOptional()
+  @IsEnum(OwnershipTransferOrderByColumn)
+  orderBy?: OwnershipTransferOrderByColumn = OwnershipTransferOrderByColumn.CREATED_AT;
 
   @ApiProperty({
     description: 'Sort order',
     enum: SortOrder,
     required: false,
-    default: SortOrder.DESC
+    default: SortOrder.DESC,
   })
-  sortedBy?: SortOrder;
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortedBy?: SortOrder = SortOrder.DESC;
 
   @ApiProperty({
     description: 'Search term',
-    required: false
+    required: false,
+    type: String,
+    example: 'pending',
   })
+  @IsOptional()
+  @IsString()
   search?: string;
 
   @ApiProperty({
     description: 'Filter by status',
-    enum: ['pending', 'approved', 'rejected', 'completed'],
-    required: false
+    enum: OwnershipTransferStatus,
+    required: false,
   })
-  status?: string;
+  @IsOptional()
+  @IsEnum(OwnershipTransferStatus)
+  status?: OwnershipTransferStatus;
 
   @ApiProperty({
     description: 'Filter by previous owner ID',
     example: 48,
-    required: false
+    required: false,
+    type: Number,
   })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   previous_owner_id?: number;
 
   @ApiProperty({
     description: 'Filter by current owner ID',
     example: 49,
-    required: false
+    required: false,
+    type: Number,
   })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
   current_owner_id?: number;
-}
-
-export enum QueryOwnershipTransferOrderByColumn {
-  CREATED_AT = 'CREATED_AT',
-  UPDATED_AT = 'UPDATED_AT',
-  TRANSACTION_IDENTIFIER = 'TRANSACTION_IDENTIFIER',
 }

--- a/api/rest/src/ownership-transfer/dto/update-ownership-transfer.dto.ts
+++ b/api/rest/src/ownership-transfer/dto/update-ownership-transfer.dto.ts
@@ -1,4 +1,3 @@
-// ownership-transfer/dto/update-ownership-transfer.dto.ts
 import { PartialType } from '@nestjs/swagger';
 import { CreateOwnershipTransferDto } from './create-ownership-transfer.dto';
 

--- a/api/rest/src/ownership-transfer/entities/ownership-transfer.entity.ts
+++ b/api/rest/src/ownership-transfer/entities/ownership-transfer.entity.ts
@@ -1,85 +1,81 @@
-// ownership-transfer/entities/ownership-transfer.entity.ts
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiHideProperty } from '@nestjs/swagger';
 import { CoreEntity } from 'src/common/entities/core.entity';
-import { Column, Entity } from 'typeorm';
-// import { Refund } from 'src/refunds/entities/refund.entity'; // Commented for future use
-// import { Shop } from 'src/shops/entities/shop.entity'; // Commented for future use
-// import { Withdraw } from 'src/withdraws/entities/withdraw.entity'; // Commented for future use
-import { User } from 'src/users/entities/user.entity';
+import { OwnershipTransferStatus } from 'src/common/enums/ownership-transfer.enum';
+import { Column, Entity, DeleteDateColumn } from 'typeorm';
 
 export class TodayTotalOrderByStatus {
-  @ApiProperty({ description: 'Pending orders count', example: 5 })
+  @ApiProperty({ description: 'Pending orders count', example: 5, type: Number })
   pending: number;
 
-  @ApiProperty({ description: 'Processing orders count', example: 3 })
+  @ApiProperty({ description: 'Processing orders count', example: 3, type: Number })
   processing: number;
 
-  @ApiProperty({ description: 'Complete orders count', example: 10 })
+  @ApiProperty({ description: 'Complete orders count', example: 10, type: Number })
   complete: number;
 
-  @ApiProperty({ description: 'Cancelled orders count', example: 2 })
+  @ApiProperty({ description: 'Cancelled orders count', example: 2, type: Number })
   cancelled: number;
 
-  @ApiProperty({ description: 'Refunded orders count', example: 1 })
+  @ApiProperty({ description: 'Refunded orders count', example: 1, type: Number })
   refunded: number;
 
-  @ApiProperty({ description: 'Failed orders count', example: 0 })
+  @ApiProperty({ description: 'Failed orders count', example: 0, type: Number })
   failed: number;
 
-  @ApiProperty({ description: 'Local facility orders count', example: 0 })
+  @ApiProperty({ description: 'Local facility orders count', example: 0, type: Number })
   localFacility: number;
 
-  @ApiProperty({ description: 'Out for delivery orders count', example: 0 })
+  @ApiProperty({ description: 'Out for delivery orders count', example: 0, type: Number })
   outForDelivery: number;
 }
 
 @Entity('ownership_transfer')
 export class OwnershipTransfer extends CoreEntity {
-  @ApiProperty({ description: 'Created by user ID', example: 6 })
+  @ApiProperty({ description: 'Created by user ID', example: 6, type: String })
   @Column()
   created_by: string;
 
-  @ApiProperty({ description: 'Deleted at timestamp', required: false })
-  @Column({ nullable: true })
-  deleted_at?: string;
-
-  @ApiProperty({ description: 'Transaction identifier', example: '2024-08-03-0001' })
+  @ApiProperty({ description: 'Transaction identifier', example: '2024-08-03-0001', type: String })
   @Column()
   transaction_identifier: string;
 
-  @ApiProperty({ description: 'Previous owner', type: () => User })
-  @Column('json', { nullable: true })
-  previous_owner?: User;
+  @ApiProperty({ description: 'Previous owner ID', required: false, type: Number })
+  @Column({ nullable: true })
+  previous_owner_id?: number;
 
-  @ApiProperty({ description: 'Current owner', type: () => User })
-  @Column('json', { nullable: true })
-  current_owner?: User;
+  @ApiProperty({ description: 'Current owner ID', required: false, type: Number })
+  @Column({ nullable: true })
+  current_owner_id?: number;
 
-  @ApiProperty({ description: 'Transfer message', required: false })
+  @ApiProperty({ description: 'Transfer message', required: false, type: String })
   @Column({ type: 'text', nullable: true })
   message?: string;
 
-  @ApiProperty({ description: 'Transfer status', enum: ['pending', 'approved', 'rejected', 'completed'], example: 'pending' })
-  @Column({ default: 'pending' })
-  status: string;
-
-  // @ApiProperty({ description: 'Shop', type: () => Shop }) // Commented for future use
-  // shop: Shop;
-
-  // @ApiProperty({ description: 'Refund information', type: [Refund], required: false }) // Commented for future use
-  // refund_info?: Refund[];
-
-  // @ApiProperty({ description: 'Withdrawal information', type: [Withdraw], required: false }) // Commented for future use
-  // withdrawal_info?: Withdraw[];
+  @ApiProperty({ description: 'Transfer status', enum: OwnershipTransferStatus, example: 'pending', type: String })
+  @Column({ default: OwnershipTransferStatus.PENDING })
+  status: OwnershipTransferStatus;
 
   @ApiProperty({ description: 'Order information', type: () => TodayTotalOrderByStatus, required: false })
   @Column('json', { nullable: true })
   order_info?: TodayTotalOrderByStatus;
 
-  // @ApiProperty({ description: 'Balance information', type: () => Balance }) // Commented for future use
-  // balance_info: Balance;
-
-  @ApiProperty({ description: 'Name', example: 'Transfer Name', required: false })
+  @ApiProperty({ description: 'Name', example: 'Transfer Name', required: false, type: String })
   @Column({ nullable: true })
   name?: string;
+
+  @ApiProperty({ description: 'Balance info (JSON)', required: false, type: Object })
+  @Column('json', { nullable: true })
+  balance_info?: any;
+
+  @ApiProperty({ description: 'Refund info (JSON)', required: false, type: Object })
+  @Column('json', { nullable: true })
+  refund_info?: any;
+
+  @ApiProperty({ description: 'Withdrawal info (JSON)', required: false, type: Object })
+  @Column('json', { nullable: true })
+  withdrawal_info?: any;
+
+  @ApiProperty({ description: 'Soft delete timestamp', required: false, type: Date })
+  @DeleteDateColumn()
+  deleted_at?: Date;
 }

--- a/api/rest/src/ownership-transfer/ownership-transfer.controller.ts
+++ b/api/rest/src/ownership-transfer/ownership-transfer.controller.ts
@@ -1,4 +1,3 @@
-// ownership-transfer/ownership-transfer.controller.ts
 import {
   Body,
   Controller,
@@ -36,7 +35,7 @@ import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { Roles } from "src/common/decorators/roles.decorator";
-import { Permission } from '../common/enums/enums';
+import { Permission, SortOrder } from '../common/enums/enums';
 
 
 @ApiTags('🔄 Ownership Transfer')
@@ -54,13 +53,13 @@ export class OwnershipTransferController {
   })
   @ApiCreatedResponse({
     description: 'Ownership transfer created successfully',
-    type: OwnershipTransfer
+    type: () => OwnershipTransfer
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @ApiBody({ type: CreateOwnershipTransferDto })
-  createOwnershipTransfer(@Body() createOwnershipTransferDto: CreateOwnershipTransferDto) {
+  create(@Body() createOwnershipTransferDto: CreateOwnershipTransferDto): Promise<OwnershipTransfer> {
     return this.ownershipTransferService.create(createOwnershipTransferDto);
   }
 
@@ -72,11 +71,11 @@ export class OwnershipTransferController {
   })
   @ApiOkResponse({
     description: 'Ownership transfers retrieved successfully',
-    type: OwnershipTransferPaginator
+    type: () => OwnershipTransferPaginator
   })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
-  findAll(@Query() query: GetOwnershipTransferDto) {
+  findAll(@Query() query: GetOwnershipTransferDto): Promise<OwnershipTransferPaginator> {
     return this.ownershipTransferService.findAll(query);
   }
 
@@ -89,19 +88,18 @@ export class OwnershipTransferController {
   @ApiParam({
     name: 'param',
     description: 'Ownership transfer ID or transaction identifier',
-    example: '10'
+    example: '10',
+    type: String,
   })
   @ApiOkResponse({
     description: 'Ownership transfer retrieved successfully',
-    type: OwnershipTransfer
+    type: () => OwnershipTransfer
   })
   @ApiNotFoundResponse({ description: 'Ownership transfer not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
-  getOwnershipTransfer(
-    @Param('param') param: string,
-    @Query('language') language: string,
-  ) {
-    return this.ownershipTransferService.getOwnershipTransfer(param, language);
+  @ApiForbiddenResponse({ description: 'Insufficient permissions' })
+  findOne(@Param('param') param: string): Promise<OwnershipTransfer> {
+    return this.ownershipTransferService.findOne(param);
   }
 
   @Put(':id')
@@ -119,7 +117,7 @@ export class OwnershipTransferController {
   })
   @ApiOkResponse({
     description: 'Ownership transfer updated successfully',
-    type: OwnershipTransfer
+    type: () => OwnershipTransfer
   })
   @ApiBadRequestResponse({ description: 'Invalid input data' })
   @ApiNotFoundResponse({ description: 'Ownership transfer not found' })
@@ -129,7 +127,7 @@ export class OwnershipTransferController {
   update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateOwnershipTransferDto: UpdateOwnershipTransferDto,
-  ) {
+  ): Promise<OwnershipTransfer> {
     return this.ownershipTransferService.update(id, updateOwnershipTransferDto);
   }
 
@@ -138,7 +136,7 @@ export class OwnershipTransferController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Delete ownership transfer',
-    description: 'Delete an ownership transfer by ID (Admin only)'
+    description: 'Soft delete an ownership transfer by ID (Admin only)'
   })
   @ApiParam({
     name: 'id',
@@ -153,7 +151,7 @@ export class OwnershipTransferController {
   @ApiNotFoundResponse({ description: 'Ownership transfer not found' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
-  deleteOwnershipTransfer(@Param('id', ParseIntPipe) id: number) {
+  remove(@Param('id', ParseIntPipe) id: number): Promise<CoreMutationOutput> {
     return this.ownershipTransferService.remove(id);
   }
 }

--- a/api/rest/src/ownership-transfer/ownership-transfer.module.ts
+++ b/api/rest/src/ownership-transfer/ownership-transfer.module.ts
@@ -1,9 +1,11 @@
-// ownership-transfer/ownership-transfer.module.ts
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { OwnershipTransferController } from './ownership-transfer.controller';
 import { OwnershipTransferService } from './ownership-transfer.service';
+import { OwnershipTransfer } from './entities/ownership-transfer.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([OwnershipTransfer])],
   controllers: [OwnershipTransferController],
   providers: [OwnershipTransferService],
   exports: [OwnershipTransferService],

--- a/api/rest/src/ownership-transfer/ownership-transfer.service.ts
+++ b/api/rest/src/ownership-transfer/ownership-transfer.service.ts
@@ -1,163 +1,217 @@
-// ownership-transfer/ownership-transfer.service.ts
 import { Injectable, NotFoundException } from '@nestjs/common';
-import ownershipTransferJSON from '@db/ownership-transfer.json';
-import { plainToClass } from 'class-transformer';
-import Fuse from 'fuse.js';
-import { paginate } from 'src/common/pagination/paginate';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Like } from 'typeorm';
 import { CreateOwnershipTransferDto } from './dto/create-ownership-transfer.dto';
 import { OwnershipTransfer } from './entities/ownership-transfer.entity';
 import { GetOwnershipTransferDto, OwnershipTransferPaginator } from './dto/get-ownership-transfer.dto';
 import { UpdateOwnershipTransferDto } from './dto/update-ownership-transfer.dto';
 import { CoreMutationOutput } from 'src/common/dto/core-mutation-output.dto';
-
-const ownershipTransfer = plainToClass(OwnershipTransfer, ownershipTransferJSON);
-
-const options = {
-  keys: ['transaction_identifier', 'status', 'previous_owner.name', 'current_owner.name'],
-  threshold: 0.3,
-};
-const fuse = new Fuse(ownershipTransfer, options);
+import { paginate } from 'src/common/pagination/paginate';
+import { SortOrder } from 'src/common/enums/enums';
+import { OwnershipTransferOrderByColumn, OwnershipTransferStatus } from 'src/common/enums/ownership-transfer.enum';
 
 @Injectable()
 export class OwnershipTransferService {
-  private ownershipTransfer: OwnershipTransfer[] = ownershipTransfer;
+  constructor(
+    @InjectRepository(OwnershipTransfer)
+    private readonly ownershipTransferRepository: Repository<OwnershipTransfer>,
+  ) {}
 
-  create(createOwnershipTransferDto: CreateOwnershipTransferDto): OwnershipTransfer {
-    const newTransfer: OwnershipTransfer = {
-      id: this.ownershipTransfer.length + 1,
-      transaction_identifier: createOwnershipTransferDto.transaction_identifier || `TR-${Date.now()}`,
-      previous_owner: createOwnershipTransferDto.previous_owner_id ? { id: createOwnershipTransferDto.previous_owner_id } as any : null,
-      current_owner: createOwnershipTransferDto.current_owner_id ? { id: createOwnershipTransferDto.current_owner_id } as any : null,
-      message: createOwnershipTransferDto.message,
-      created_by: createOwnershipTransferDto.created_by?.toString() || '1',
-      status: createOwnershipTransferDto.status || 'pending',
-      order_info: null,
-      name: null,
-      created_at: new Date(),
-      updated_at: new Date(),
-    } as OwnershipTransfer;
+  async create(createDto: CreateOwnershipTransferDto): Promise<OwnershipTransfer> {
+    const transactionIdentifier = await this.getUniqueTransactionIdentifier(
+      createDto.transaction_identifier,
+    );
 
-    this.ownershipTransfer.push(newTransfer);
-    return newTransfer;
-  }
-
-  findAll({ search, limit, page, status, previous_owner_id, current_owner_id, orderBy, sortedBy }: GetOwnershipTransferDto): OwnershipTransferPaginator {
-    if (!page) page = 1;
-    if (!limit) limit = 10;
-    
-    let data: OwnershipTransfer[] = [...this.ownershipTransfer];
-
-    // Filter by status
-    if (status) {
-      data = data.filter(item => item.status === status);
-    }
-
-    // Filter by previous owner ID
-    if (previous_owner_id) {
-      data = data.filter(item => item.previous_owner?.id === previous_owner_id);
-    }
-
-    // Filter by current owner ID
-    if (current_owner_id) {
-      data = data.filter(item => item.current_owner?.id === current_owner_id);
-    }
-
-    // Search functionality
-    if (search) {
-      const parseSearchParams = search.split(';');
-      for (const searchParam of parseSearchParams) {
-        const [key, value] = searchParam.split(':');
-        if (key === 'status' && value) {
-          data = data.filter(item => item.status === value);
-        } else if (key === 'transaction_identifier' && value) {
-          data = data.filter(item => item.transaction_identifier?.includes(value));
-        } else {
-          data = fuse.search(search)?.map(({ item }) => item);
-        }
-      }
-    }
-
-    // Sort data
-    const sortColumn = this.mapOrderByToColumn(orderBy);
-    const sortOrder = sortedBy || 'asc';
-    data.sort((a, b) => {
-      const aValue = a[sortColumn as keyof OwnershipTransfer];
-      const bValue = b[sortColumn as keyof OwnershipTransfer];
-      if (sortOrder === 'asc') {
-        return aValue > bValue ? 1 : -1;
-      } else {
-        return aValue < bValue ? 1 : -1;
-      }
+    const newTransfer = this.ownershipTransferRepository.create({
+      transaction_identifier: transactionIdentifier,
+      previous_owner_id: createDto.previous_owner_id,
+      current_owner_id: createDto.current_owner_id,
+      message: createDto.message,
+      created_by: createDto.created_by?.toString() || '1',
+      status: createDto.status || OwnershipTransferStatus.PENDING,
     });
 
-    const startIndex = (page - 1) * limit;
-    const endIndex = page * limit;
-    const results = data.slice(startIndex, endIndex);
-    
-    const url = `/ownership-transfer?search=${search}&limit=${limit}`;
-    
+    return this.ownershipTransferRepository.save(newTransfer);
+  }
+
+  async findAll({
+    page = 1,
+    limit = 30,
+    search,
+    status,
+    previous_owner_id,
+    current_owner_id,
+    orderBy = OwnershipTransferOrderByColumn.CREATED_AT,
+    sortedBy = SortOrder.DESC,
+  }: GetOwnershipTransferDto): Promise<OwnershipTransferPaginator> {
+    const query = this.ownershipTransferRepository.createQueryBuilder('ownershipTransfer');
+
+    if (status) {
+      query.andWhere('ownershipTransfer.status = :status', { status });
+    }
+
+    if (previous_owner_id) {
+      query.andWhere('ownershipTransfer.previous_owner_id = :previous_owner_id', {
+        previous_owner_id,
+      });
+    }
+
+    if (current_owner_id) {
+      query.andWhere('ownershipTransfer.current_owner_id = :current_owner_id', {
+        current_owner_id,
+      });
+    }
+
+    if (search) {
+      query.andWhere(
+        '(LOWER(ownershipTransfer.transaction_identifier) LIKE :search OR LOWER(ownershipTransfer.status) LIKE :search OR LOWER(COALESCE(ownershipTransfer.message, \'\')) LIKE :search)',
+        { search: `%${search.toLowerCase()}%` },
+      );
+    }
+
+    let orderColumn: string;
+    switch (orderBy) {
+      case OwnershipTransferOrderByColumn.TRANSACTION_IDENTIFIER:
+        orderColumn = 'transaction_identifier';
+        break;
+      case OwnershipTransferOrderByColumn.STATUS:
+        orderColumn = 'status';
+        break;
+      case OwnershipTransferOrderByColumn.UPDATED_AT:
+        orderColumn = 'updated_at';
+        break;
+      default:
+        orderColumn = 'created_at';
+    }
+
+      query.orderBy(
+        `ownershipTransfer.${orderColumn}`,
+        sortedBy === SortOrder.ASC ? 'ASC' : 'DESC',
+      );
+
+      const safePage = Number(page) || 1;
+      const safeLimit = Number(limit) || 30;
+      const [results, total] = await query
+        .skip((safePage - 1) * safeLimit)
+        .take(safeLimit)
+        .getManyAndCount();
+
+      const url = `/ownership-transfer?limit=${safeLimit}`;
+      const paginationInfo = paginate(total, safePage, safeLimit, results.length, url);
+
     return {
       data: results,
-      ...paginate(data.length, page, limit, results.length, url),
+      ...paginationInfo,
+        current_page: safePage,
+        per_page: safeLimit,
+      total,
+        last_page: Math.ceil(total / safeLimit),
+        from: total === 0 ? 0 : (safePage - 1) * safeLimit + 1,
+        to: Math.min(safePage * safeLimit, total),
     };
   }
 
-  getOwnershipTransfer(param: string, language: string): OwnershipTransfer {
-    const transfer = this.ownershipTransfer.find(
-      (p) => p.id === Number(param) || p.transaction_identifier === param
-    );
+  async findOne(param: string): Promise<OwnershipTransfer> {
+    const isId = !isNaN(Number(param));
+      const transfer = await this.ownershipTransferRepository.findOne({
+        where: isId ? { id: Number(param) } : { transaction_identifier: param },
+      });
     
     if (!transfer) {
-      throw new NotFoundException(`Ownership transfer with ID/identifier "${param}" not found`);
+      throw new NotFoundException(`Ownership transfer with ${isId ? 'ID' : 'identifier'} "${param}" not found`);
     }
     
     return transfer;
   }
 
-  update(id: number, updateOwnershipTransferDto: UpdateOwnershipTransferDto): OwnershipTransfer {
-    const index = this.ownershipTransfer.findIndex((p) => p.id === id);
-    
-    if (index === -1) {
+  async update(id: number, updateDto: UpdateOwnershipTransferDto): Promise<OwnershipTransfer> {
+    const transfer = await this.ownershipTransferRepository.findOne({ where: { id } });
+
+    if (!transfer) {
       throw new NotFoundException(`Ownership transfer with ID ${id} not found`);
     }
-    
-    const baseTransfer = this.ownershipTransfer[index];
-    const updated = {
-      ...baseTransfer,
-      ...updateOwnershipTransferDto,
-      updated_at: new Date(),
-    } as OwnershipTransfer;
-    
-    if (updated.created_by && typeof updated.created_by !== 'string') {
-      updated.created_by = String(updated.created_by);
-    }
-    
-    this.ownershipTransfer[index] = updated;
-    
-    return this.ownershipTransfer[index];
+
+    const updated = this.ownershipTransferRepository.merge(transfer, {
+      ...updateDto,
+      created_by:
+        updateDto.created_by !== undefined
+          ? updateDto.created_by.toString()
+          : transfer.created_by,
+    });
+
+    return this.ownershipTransferRepository.save(updated);
   }
 
-  private mapOrderByToColumn(orderBy: string | undefined): string {
-    const columnMap: Record<string, string> = {
-      'CREATED_AT': 'created_at',
-      'UPDATED_AT': 'updated_at',
-      'TRANSACTION_IDENTIFIER': 'transaction_identifier',
-    };
-    return columnMap[orderBy] || 'created_at';
-  }
+  async remove(id: number): Promise<CoreMutationOutput> {
+    const transfer = await this.ownershipTransferRepository.findOne({ where: { id } });
 
-  remove(id: number): CoreMutationOutput {
-    const index = this.ownershipTransfer.findIndex((p) => p.id === id);
-    
-    if (index === -1) {
+    if (!transfer) {
       throw new NotFoundException(`Ownership transfer with ID ${id} not found`);
     }
-    
-    this.ownershipTransfer.splice(index, 1);
+
+    await this.ownershipTransferRepository.delete(id);
     
     return {
       success: true,
       message: `Ownership transfer #${id} removed successfully`,
     };
+  }
+
+  private async generateTransactionIdentifier(): Promise<string> {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const prefix = `${year}-${month}-${day}-`;
+    const sequence = String(
+      (await this.ownershipTransferRepository.count({
+        where: { transaction_identifier: Like(`${prefix}%`) },
+      })) + 1,
+    ).padStart(4, '0');
+    return `${prefix}${sequence}`;
+  }
+
+  private async getUniqueTransactionIdentifier(preferredIdentifier?: string): Promise<string> {
+    const hasUniquePreferredIdentifier = preferredIdentifier
+      ? !(await this.ownershipTransferRepository.exist({
+          where: { transaction_identifier: preferredIdentifier },
+        }))
+      : false;
+
+    if (hasUniquePreferredIdentifier) {
+      return preferredIdentifier as string;
+    }
+
+    let generatedIdentifier = await this.generateTransactionIdentifier();
+    while (
+      await this.ownershipTransferRepository.exist({
+        where: { transaction_identifier: generatedIdentifier },
+      })
+    ) {
+      generatedIdentifier = await this.generateTransactionIdentifier();
+    }
+
+    return generatedIdentifier;
+  }
+
+  // Helper method to get by previous owner
+  async findByPreviousOwner(previousOwnerId: number): Promise<OwnershipTransfer[]> {
+    return this.ownershipTransferRepository.find({
+      where: { previous_owner_id: previousOwnerId },
+    });
+  }
+
+  // Helper method to get by current owner
+  async findByCurrentOwner(currentOwnerId: number): Promise<OwnershipTransfer[]> {
+    return this.ownershipTransferRepository.find({
+      where: { current_owner_id: currentOwnerId },
+    });
+  }
+
+  // Helper method to get by status
+  async findByStatus(status: OwnershipTransferStatus): Promise<OwnershipTransfer[]> {
+    return this.ownershipTransferRepository.find({
+      where: { status },
+    });
   }
 }


### PR DESCRIPTION
Convert ownership-transfer from in-memory fixtures to a TypeORM-backed module and introduce shared enums. Added OwnershipTransferStatus and OwnershipTransferOrderByColumn enums; updated entity to store owner IDs, use enum status, add JSON fields and soft-delete column. Reworked service to use Repository with async create/find/update/remove, searchable pagination, sorting, and unique transaction identifier generation. Updated DTOs and validations, expanded paginator shape, adjusted controller method names/signatures and Swagger metadata, registered the entity in the module, and updated the seeder to use owner IDs and the new enum types.